### PR TITLE
Add initial functionality to run a service

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -3,3 +3,7 @@ Service
 #######
 
 A framework for running a Python service consuming from a Kafka topic.
+
+.. code-block:: shell
+
+   $ python -m ingestion.service <service name>

--- a/ingestion/__init__.py
+++ b/ingestion/__init__.py
@@ -1,0 +1,3 @@
+"""Namespaces are one honking great idea -- let's do more of those!"""
+
+__import__('pkg_resources').declare_namespace(__name__)

--- a/ingestion/service.py
+++ b/ingestion/service.py
@@ -1,0 +1,78 @@
+"""Implementation of the service."""
+
+from collections import namedtuple
+from importlib import import_module
+import sys
+
+import click
+
+from ingestion.kafka import connect, Consumer
+
+KafkaInfo = namedtuple('KafkaInfo', ('host', 'port', 'topic', 'group'))
+
+
+class Application:
+
+    """This is a class."""
+
+    _consumer = None
+
+    def __init__(self, *, host, port, topic, callback, group=None):
+        """Initialize the class."""
+        self.info = KafkaInfo(host, port, topic, group)
+        self.callback = callback
+
+    def _initialize(self):
+        client = connect(host=self.info.host, port=self.info.port)
+
+        self._consumer = Consumer(
+            client=client, topic=self.info.topic, group=self.info.group)
+
+    def run_forever(self):
+        """Run the class."""
+        if not self._consumer:
+            self._initialize()
+
+        messages = self._consumer.read()
+        while True:
+            try:
+                message = next(messages)
+            except KeyboardInterrupt:
+                break
+            except Exception:
+                continue
+
+            self.callback(message)
+
+
+@click.command(context_settings={'help_option_names': ['-h', '--help']})
+@click.argument('service')
+def run(service):
+    """Run an ingestion service."""
+    try:
+        settings = import_module('{}.settings'.format(service))
+    except ImportError:
+        # If the service can't be imported or it doesn't contain the
+        # necessary attributes, get out.
+        raise click.BadOptionUsage(
+            'service', '{} is not a valid service. No settings.'.format(service))
+    try:
+        process = import_module('{}.process'.format(service))
+    except ImportError:
+        # If the service can't be imported or it doesn't contain the
+        # necessary attributes, get out.
+        raise click.BadOptionUsage(
+            'service', '{} is not a valid service. No process.'.format(service))
+    print('SETTINGS', dir(settings))
+    app = Application(
+        host=settings.KAFKA_BROKER_HOST,
+        port=settings.KAFKA_BROKER_PORT,
+        topic=settings.KAFKA_TOPIC_INBOUND,
+        group=settings.KAFKA_GROUP_NAME,
+        callback=process.run,
+    )
+    app.run_forever()
+
+
+if __name__ == '__main__':
+    sys.exit(run())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[bdist_wheel]
+universal = 1

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,16 @@
+from setuptools import find_packages, setup
+
+setup(
+    name='ingestion.service',
+    version='0.0.1',
+    namespace_packages=['ingestion'],
+    packages=find_packages(exclude=['tests']),
+    install_requires=[
+        'click==4.0',
+        'ingestion.kafka',
+        'setuptools',
+    ],
+    tests_require=[
+        'tox',
+    ],
+)


### PR DESCRIPTION
There are still changes to be made (e.g., checking for required
attributes of imported modules), but this is the intitial pass at the
functionality of ingestion.service. It exposes its functionality through
the commandline, allowing services to be run using:

```
$ python -m ingestion.service <service name>
```
