### PR TITLE
Use ConnectionInfo provided by ingestion.kafka

### DIFF
--- a/ingestion/service.py
+++ b/ingestion/service.py
@@ -1,14 +1,12 @@
 """Implementation of the service."""
 
-from collections import namedtuple
 from importlib import import_module
 import sys
 
 import click
 
-from ingestion.kafka import connect, Consumer
+from ingestion.kafka import connect, ConnectionInfo, Consumer
 
-KafkaInfo = namedtuple('KafkaInfo', ('host', 'port', 'topic', 'group'))
 
 
 class Application:
@@ -19,7 +17,7 @@ class Application:
 
     def __init__(self, *, host, port, topic, callback, group=None):
         """Initialize the class."""
-        self.info = KafkaInfo(host, port, topic, group)
+        self.info = ConnectionInfo(host, port, topic, group)
         self.callback = callback
 
     def _initialize(self):

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'click==4.0',
-        'ingestion.kafka',
+        'ingestion.kafka>=0.0.2',
         'setuptools',
     ],
     tests_require=[


### PR DESCRIPTION
Version 0.0.2 of ingestion.kafka provides a namedtuple containing
information about connecting to Kafka that's identical to the one in
ingestion.service. By upgrading to the newer version of ingestion.kafka,
its version of the namedtuple can be used instead.
