### PR TITLE
Use new Kafka versioning

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'click==4.0',
-        'ingestion.kafka>=0.0.2',
+        'ingestion.kafka>=0.2.0',
         'setuptools',
     ],
     tests_require=[


### PR DESCRIPTION
ingestion.kafka changed how it handles version numbers. The new
implementation needs to be used by ingestion.service.
