### PR TITLE
Switch to using Kafka plugin

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         'click==4.0',
-        'ingestion.kafka>=0.2.0',
+        'ingestion.kafka>=0.3.0',
         'setuptools',
     ],
     tests_require=[


### PR DESCRIPTION
In order to allow the plugin system to set default values for settings,
the way settings work inside `Application` needs to change. In addition
to switching all Kafka-related functionality over to the new plugin,
settings are now converted from an object -- typically they'll be a
module, but classes work, too -- to a dict.
