### PR TITLE
Add an application registry

### DIFF
--- a/ingestion/registry.py
+++ b/ingestion/registry.py
@@ -1,0 +1,40 @@
+"""Application registry."""
+
+__all__ = ('Registry')
+
+
+class Registry:
+
+    """An application registry.
+
+    The registry provides easy access to the most recently registered
+    application.
+
+    .. versionadded:: 0.3.0
+    """
+
+    def __init__(self):
+        """Initialize the class."""
+        self._applications = []
+
+    @property
+    def current_application(self):
+        """Return the most recently registered application.
+
+        Returns:
+            :class:~`ingestion.service.Application`: The most recent
+              application. None if no applications have been registered.
+        """
+        if not self._applications:
+            return None
+        return self._applications[-1]
+
+    @current_application.setter
+    def current_application(self, app):
+        """Register a new application.
+
+        Args:
+            app (:class:`~ingestion.service.Application`): The
+              application to register.
+        """
+        self._applications.append(app)

--- a/ingestion/service.py
+++ b/ingestion/service.py
@@ -6,6 +6,11 @@ import click
 
 from ingestion.kafka import Kafka
 from ingestion.importer import import_from_service, ServiceImportError
+from ingestion.registry import Registry
+
+__all__ = ('Application',)
+
+registry = Registry()
 
 
 class Application:

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,6 +2,8 @@
 
 import pytest
 
+from ingestion.registry import Registry
+
 
 @pytest.fixture
 def modules_tmpdir(tmpdir, monkeypatch):
@@ -21,3 +23,9 @@ def mock_service(modules_tmpdir):
     # Add a couple of other modules that can be used for testing errors.
     service.join('bad_import.py').write('import not_a_real_module')
     service.join('type_error.py').write('1 + "a"')
+
+
+@pytest.fixture
+def registry():
+    """Create an application registry."""
+    return Registry()

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,0 +1,33 @@
+"""Test the application registry."""
+
+
+def test_adding_to_empty_registry(registry):
+    """Test that adding to an empty registry returns the added app."""
+    obj = object()
+    registry.current_application = obj
+    assert registry.current_application == obj
+
+
+def test_adding_multiple_to_registry(registry):
+    """Test that a registry returns the newest app added."""
+    obj1 = object()
+    obj2 = object()
+    registry.current_application = obj1
+    registry.current_application = obj2
+    assert registry.current_application == obj2
+
+
+def test_empty_registry(registry):
+    """Test that an empty registry returns None."""
+    assert registry.current_application is None
+
+
+def test_registry_retains_apps(registry):
+    """Test that a registry retains all previous apps."""
+    obj1 = object()
+    obj2 = object()
+    registry.current_application = obj1
+    registry.current_application = obj2
+    # This is an implementation detail and probably needs to be tested
+    # in a better way.
+    assert obj1 in registry._applications


### PR DESCRIPTION
There will be times when an application instance is needed but not
directly available. By maintaining a registry of applications, they can
be fetched at any time.

The most recent application can be set and retrieved through the
registry instance's `current_application` property.

TODO: The registry probably needs to be cleaned up when an application
falls out of scope.
