### PR TITLE
Prevent access to Registry.current_app

### DIFF
--- a/ingestion/registry.py
+++ b/ingestion/registry.py
@@ -18,6 +18,32 @@ class Registry:
         self._applications = []
 
     @property
+    def current_app(self):
+        """Raise AttributeError on access.
+
+        This is not a real property. But it is too easy to try to use it
+        instead of ``current_application``.
+
+        Raises:
+            AttributeError
+        """
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+            self.__class__.__name__, 'current_app'))
+
+    @current_app.setter
+    def current_app(self, value):
+        """Raise AttributeError on assignment.
+
+        This is not a real property. But it is too easy to try to use it
+        instead of ``current_application``.
+
+        Raises:
+            AttributeError
+        """
+        raise AttributeError("'{}' object has no attribute '{}'".format(
+            self.__class__.__name__, 'current_app'))
+
+    @property
     def current_application(self):
         """Return the most recently registered application.
 

--- a/tests/test_registry.py
+++ b/tests/test_registry.py
@@ -1,5 +1,7 @@
 """Test the application registry."""
 
+import pytest
+
 
 def test_adding_to_empty_registry(registry):
     """Test that adding to an empty registry returns the added app."""
@@ -15,6 +17,18 @@ def test_adding_multiple_to_registry(registry):
     registry.current_application = obj1
     registry.current_application = obj2
     assert registry.current_application == obj2
+
+
+def test_current_app_raises_attributeerror(registry):
+    """Test that the current_app property raises AttributeError."""
+    with pytest.raises(AttributeError):
+        registry.current_app
+
+
+def test_current_app_setter_raises_attributeerror(registry):
+    """Test that the current_app setter raises AttributeError."""
+    with pytest.raises(AttributeError):
+        registry.current_app = 1
 
 
 def test_empty_registry(registry):


### PR DESCRIPTION
It's all too easy to typo `current_application` as `current_app`,
especially if you're familiar with Flask. To prevent this from
happening, trying to get or set `current_app` will raise an
`AttributeError`.
