### PR TITLE
Add a class for creating lazy proxies

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -15,3 +15,8 @@ Configuration
 
 .. autoclass:: henson.config.Config
    :members:
+
+Proxies
+=======
+
+.. autoclass:: henson.utils.ProxyObject

--- a/henson/utils.py
+++ b/henson/utils.py
@@ -1,0 +1,159 @@
+"""Utilities."""
+
+
+class ProxyObject:
+
+    """A wrapper around an object to delay its instantiation.
+
+    A proxy can be created to either an object or a callable. When using
+    a callable, it will not be executed until an attribute of the object
+    it creates is accessed.
+
+    Args:
+        proxied (object or callable): The object to proxy or the
+          callable that will instantiate it.
+
+    .. note::
+
+       The result of the callable is not cached. It will be executed
+       upon each access.
+    """
+
+    # This class is inspired heavily be werkzeug.local.LocalProxy and
+    # wrapt.wrappers.ObjectProxy.
+
+    __slots__ = ('__proxied',)
+
+    def __init__(self, proxied):
+        """Initialize the class."""
+        object.__setattr__(self, '_ProxyObject__proxied', proxied)
+
+    @property
+    def _current_object(self):
+        """Return the current object."""
+        if callable(self.__proxied):
+            return self.__proxied()
+        else:
+            return self.__proxied
+
+    # The properties and methods that follow implement the data model.
+    # They serve as passthroughs to the proxied object. Whenever
+    # possible a lambda is used to shorten the code. Full methods are
+    # used whenever the lambda syntax won't suffice.
+
+    __class__ = property(lambda s: s._current_object.__class__)
+    __dict__ = property(lambda s: s._current_object.__dict__)
+    __name__ = property(lambda s: s._current_object.__name__)
+
+    # Basic
+
+    def __repr__(self):
+        """Return a printable representation."""
+        try:
+            return repr(self._current_object)
+        except RuntimeError:
+            return '<{}: unbound>'.format(self.__class__.__name__)
+
+    def __str__(self):
+        """Return a readable representation."""
+        try:
+            return str(self._current_object)
+        except RuntimeError:
+            return repr(self)
+
+    __lt__ = lambda s, o: s._current_object < o
+    __le__ = lambda s, o: s._current_object <= o
+    __eq__ = lambda s, o: s._current_object == o
+    __ne__ = lambda s, o: s._current_object != o
+    __gt__ = lambda s, o: s._current_object > o
+    __ge__ = lambda s, o: s._current_object >= o
+
+    __hash__ = lambda s: hash(s._current_object)
+
+    def __bool__(self):
+        """Return a boolean representation."""
+        try:
+            return bool(self._current_object)
+        except RuntimeError:
+            return False
+
+    # Attribute access
+
+    __getattr__ = lambda s, n: getattr(s._current_object, n)
+    __setattr__ = lambda s, n, v: setattr(s._current_object, n, v)
+    __delattr__ = lambda s, n: delattr(s._current_object, n)
+
+    def __dir__(self):
+        """Return a directory listing."""
+        try:
+            return dir(self._current_object)
+        except RuntimeError:
+            return []
+
+    # Callable
+
+    __call__ = lambda s, *a, **kw: s._current_object(*a, **kw)
+
+    # Containers
+
+    __len__ = lambda s: len(s._current_object)
+
+    __getitem__ = lambda s, k: s._current_object[k]
+
+    def __setitem__(self, key, value):
+        """Assign a value to a key."""
+        self._current_object[key] = value
+
+    def __delitem__(self, key):
+        """Delete a key."""
+        del self._current_object[key]
+
+    __iter__ = lambda s: iter(s._current_object)
+    __contains__ = lambda s, i: i in s._current_object
+
+    # Numeric
+
+    __add__ = lambda s, o: s._current_object + o
+    __sub__ = lambda s, o: s._current_object - o
+    __mul__ = lambda s, o: s._current_object * o
+    __truediv__ = lambda s, o: s._current_object / o
+    __floordiv__ = lambda s, o: s._current_object // o
+    __mod__ = lambda s, o: s._current_object % o
+    __divmod__ = lambda s, o: divmod(s._current_object, o)
+    __pow__ = lambda s, o: s._current_object ** o
+    __lshift__ = lambda s, o: s._current_object << o
+    __rshift__ = lambda s, o: s._current_object >> o
+    __and__ = lambda s, o: s._current_object & o
+    __xor__ = lambda s, o: s._current_object ^ o
+    __or__ = lambda s, o: s._current_object | o
+
+    __radd__ = lambda s, o: o + s._current_object
+    __rsub__ = lambda s, o: o - s._current_object
+    __rmul__ = lambda s, o: o * s._current_object
+    __rtruediv__ = lambda s, o: o / s._current_object
+    __rfloordiv__ = lambda s, o: o // s._current_object
+    __rmod__ = lambda s, o: o % s._current_object
+    __rdivmod__ = lambda s, o: divmod(o, s._current_object)
+    __rpow__ = lambda s, o: o ** s._current_object
+    __rlshift__ = lambda s, o: o << s._current_object
+    __rrshift__ = lambda s, o: o >> s._current_object
+    __rand__ = lambda s, o: o & s._current_object
+    __rxor__ = lambda s, o: o ^ s._current_object
+    __ror__ = lambda s, o: o | s._current_object
+
+    __neg__ = lambda s: -(s._current_object)
+    __pos__ = lambda s: +(s._current_object)
+    __abs__ = lambda s: abs(s._current_object)
+    __invert__ = lambda s: ~(s._current_object)
+
+    __complex__ = lambda s: complex(s._current_object)
+    __int__ = lambda s: int(s._current_object)
+    __round__ = lambda s, n=0: round(s._current_object, n)
+    __float__ = lambda s: float(s._current_object)
+
+    __index__ = lambda s: s._current_object.__index__()
+
+    # Context manager
+
+    __enter__ = lambda s: s._current_object.__enter__()
+    __exit__ = lambda s, *a, **kw: s._current_object.__exit__(*a, **kw)

--- a/tests/test_proxy_object.py
+++ b/tests/test_proxy_object.py
@@ -1,0 +1,232 @@
+"""Test the utils module."""
+
+import pytest
+
+from henson.utils import ProxyObject
+
+
+def test_callable():
+    """Test that the proxied object can be a callable."""
+    f = lambda: 42
+    expected = 42
+    actual = ProxyObject(f)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('f', (str, repr, hash, bool))
+def test_data_model_basic(f):
+    """Test the basic methods of the data model."""
+    expected = f(42)
+    actual = f(ProxyObject(42))
+    assert actual == expected
+
+
+def test_data_model_compare_equal_to():
+    """Test equal to comparisons."""
+    assert ProxyObject(41) == 41
+    assert ProxyObject(42) == 42
+    assert ProxyObject(43) == 43
+
+
+def test_data_model_compare_greater_than():
+    """Test greater than comparisons."""
+    proxied = ProxyObject(42)
+    assert proxied > 41
+    assert not (proxied > 42)
+    assert not (proxied > 43)
+
+
+def test_data_model_compare_greater_than_equal_to():
+    """Test greater than or equal to comparisons."""
+    proxied = ProxyObject(42)
+    assert proxied >= 41
+    assert proxied >= 42
+    assert not (proxied >= 43)
+
+
+def test_data_model_compare_less_than():
+    """Test less than comparisons."""
+    proxied = ProxyObject(42)
+    assert not (proxied < 41)
+    assert not (proxied < 42)
+    assert proxied < 43
+
+
+def test_data_model_compare_less_than_equal_to():
+    """Test less than or equal to comparisons."""
+    proxied = ProxyObject(42)
+    assert not (proxied <= 41)
+    assert proxied <= 42
+    assert proxied <= 43
+
+
+def test_data_model_compare_not_equal():
+    """Test not equal comparisons."""
+    assert ProxyObject(42) != 41
+    assert ProxyObject(42) != 43
+
+
+def test_data_model_container_contains():
+    """Test containment."""
+    proxied = ProxyObject([42, 43])
+    assert 42 in proxied
+    assert 43 in proxied
+    assert 44 not in proxied
+
+
+def test_data_model_container_len():
+    """Test length."""
+    expected = 2
+    actual = len(ProxyObject([42, 43]))
+    assert actual == expected
+
+
+def test_data_model_numeric_abs():
+    """Test absolute value."""
+    expected = 42
+    actual = abs(ProxyObject(-42))
+    assert actual == expected
+
+
+@pytest.mark.parametrize('proxy_value, value, expected', (
+    (42, 1, 43),
+    ('spam', 'eggs', 'spameggs'),
+    ([1], [2], [1, 2]),
+))
+def test_data_model_numeric_add(proxy_value, value, expected):
+    """Test addition."""
+    assert ProxyObject(proxy_value) + value == expected
+    # While adding integers is commutative, adding other types isn't.
+    assert proxy_value + ProxyObject(value) == expected
+
+
+def test_data_model_numeric_and():
+    """Test bitwise and."""
+    proxied = ProxyObject(42)
+    assert proxied & 2 == 2
+    assert 2 & proxied == 2
+
+
+def test_data_model_numeric_division():
+    """Test division."""
+    proxied = ProxyObject(42)
+    assert proxied / 1 == 42
+    assert 21 / proxied == 0.5
+
+
+def test_data_model_numeric_divmod():
+    """Test divmod."""
+    proxied = ProxyObject(42)
+    assert divmod(proxied, 4) == (10, 2)
+    assert divmod(43, proxied) == (1, 1)
+
+
+def test_data_model_numeric_float():
+    """Test the float constructor."""
+    assert float(ProxyObject('42.1')) == 42.1
+
+
+def test_data_model_numeric_floor():
+    """Test floor division."""
+    proxied = ProxyObject(42)
+    assert proxied // 3 == 14
+    assert 85 // proxied == 2
+
+
+def test_data_model_numeric_int():
+    """Test the int constructor."""
+    expected = 42
+    actual = int(ProxyObject('42'))
+    assert actual == expected
+
+
+def test_data_model_numeric_invert():
+    """Test the inversion operator."""
+    expected = -43
+    actual = ~ProxyObject(42)
+    assert actual == expected
+
+
+def test_data_model_numeric_mod():
+    """Test modulo operation."""
+    proxied = ProxyObject(42)
+    assert proxied % 4 == 2
+    assert 43 % proxied == 1
+
+
+@pytest.mark.parametrize('proxy_value, value, expected', (
+    (42, 2, 84),
+    ('spam', 2, 'spamspam'),
+    ([1], 2, [1, 1]),
+))
+def test_data_model_numeric_mul(proxy_value, value, expected):
+    """Test multiplication."""
+    assert ProxyObject(proxy_value) * value == expected
+    assert value * ProxyObject(proxy_value) == expected
+
+
+def test_data_model_numeric_or():
+    """Test bitwise or."""
+    proxied = ProxyObject(42)
+    assert proxied | 2 == 42
+    assert 2 | proxied == 42
+
+
+def test_data_model_numeric_neg():
+    """Test the negation operator."""
+    expected = -42
+    actual = -ProxyObject(42)
+    assert actual == expected
+
+
+def test_data_model_numeric_pos():
+    """Test the positive unary operator."""
+    expected = -42
+    actual = +ProxyObject(-42)
+    assert actual == expected
+
+
+def test_data_model_numeric_pow():
+    """Test power."""
+    proxied = ProxyObject(42)
+    assert proxied ** 2 == 1764
+    assert 2 ** proxied == 4398046511104
+
+
+def test_data_model_numeric_round():
+    """Test rounding."""
+    expected = 43.0
+    actual = round(ProxyObject(42.6))
+    assert actual == expected
+
+
+def test_data_model_numeric_sub():
+    """Test subtraction."""
+    proxied = ProxyObject(42)
+    assert proxied - 1 == 41
+    assert 43 - proxied == 1
+
+
+def test_data_model_numeric_xor():
+    """Test bitwise xor."""
+    proxied = ProxyObject(42)
+    assert proxied ^ 2 == 40
+    assert 2 ^ proxied == 40
+
+
+def test_is_original():
+    """Test that the proxied object is the original."""
+    expected = {'a': 1}
+    actual = ProxyObject(expected)
+    actual['b'] = 2
+    assert actual == expected
+
+
+def test_is_original_type():
+    """Test that the proxied object is the original type."""
+    assert isinstance(ProxyObject(42), int)
+
+
+def test_is_proxy_type():
+    """Test that the proxied object is a ProxyObject."""
+    assert isinstance(ProxyObject(42), ProxyObject)


### PR DESCRIPTION
A new class, `ProxyObject`, is being added; it acts as a proxy around
any object or callable. The main advantage of the class is that it will
delay the execution of the callable until it's attributes are accessed.
It will allow for references to be created at runtime to things that
don't yet exist.

When using a callable it does not cache the result.
