### PR TITLE
Change Consumer Interface to be anything iterable

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -6,16 +6,14 @@ A framework for running a Python service driven by a consumer.
 
 .. code::
 
-    from henson import Application
+    from itertools import count
 
-    class Consumer:
-        def read(self):
-            yield
+    from henson import Application
 
     def callback(app, data):
         print(data)
 
-    app = Application(__name__, consumer=consumer, callback=callback)
+    app = Application(__name__, consumer=count(), callback=callback)
 
     if __name__ == '__main__':
         app.run_forever()

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -29,7 +29,7 @@ Quickstart
         def __init__(self, filename):
             self.filename = filename
 
-        def read(self):
+        def __iter__(self):
             with open(self.filename) as f:
                 yield from f
 

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -2,10 +2,9 @@
 Consumer Interface
 ==================
 
-To work with Henson, a consumer must conform to the Consumer Interface. It must
-be an object with a method called ``read`` that accepts no arguments. (The one
-exception would be class or instance argument to a class or instance method.)
-The ``read`` method must return an iterable.
+To work with Henson, a consumer must conform to the Consumer Interface. To
+conform to the interface, the object must be iterable. It can be a built-in
+type, a generator, a custom class with an ``__iter__`` method, etc.
 
 Below is a sample implementation.
 
@@ -18,7 +17,14 @@ Below is a sample implementation.
         def __init__(self, filename):
             self.filename = filename
 
-        def read(self):
+        def __iter__(self):
             """Return a generator that yields lines from the file."""
             with open(self.filename) as f:
                 yield from f
+
+This can be simplified to just use the stream object directly.
+
+.. code::
+
+    with open(filename) as f:
+        # f can be used as the consumer.

--- a/henson/base.py
+++ b/henson/base.py
@@ -19,10 +19,10 @@ class Application:
         name (str): The name of the application.
         settings (object, optional): An object with attributed-based
           settings.
-        consumer (optional): Any object that has a ``read`` message
-          which returns a generator that yields instances of any type
-          that is supported by ``callback``. While this isn't required,
-          it must be provided before the application can be run.
+        consumer (optional): Any object that is an iterator or an
+          iterable and yields instances of any type that is supported by
+          ``callback``. While this isn't required, it must be provided
+          before the application can be run.
         callback (callable, optional): A callable object that takes two
           arguments, an instance of this class and the incoming message.
           While this isn't required, it must be prodivded before the
@@ -58,7 +58,7 @@ class Application:
         if not callable(self.callback):
             raise TypeError('The specified callback is not callable.')
 
-        messages = self.consumer.read()
+        messages = iter(self.consumer)
         while True:
             try:
                 message = next(messages)


### PR DESCRIPTION
When Henson consumes through its consumer instance, it uses the instance
as an iterator, with the exception that the consumer must provide a
method called `read` which returns the iterator. The Consumer Interface
can be simplified to iterate over the consumer directly. This means that
custom classes and won't be needed just to wrap around iterators.
