### PR TITLE
Add a proxy for the current application

### DIFF
--- a/henson/__init__.py
+++ b/henson/__init__.py
@@ -1,3 +1,4 @@
 """Henson."""
 
 from .base import Application  # NOQA
+from .globals import current_application  # NOQA

--- a/henson/globals.py
+++ b/henson/globals.py
@@ -1,0 +1,14 @@
+"""Global objects."""
+
+from .base import registry as _registry
+from .utils import ProxyObject
+
+
+def _get_application():
+    app = _registry.current_application
+    if app is None:
+        raise RuntimeError('No application instance has been registered.')
+    return app
+
+
+current_application = ProxyObject(_get_application)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -2,7 +2,22 @@
 
 import pytest
 
+import henson.base
 from henson.registry import Registry
+
+
+@pytest.fixture
+def mock_registry(request):
+    """Create a new application registry and restore the old one."""
+    original = henson.base.registry._applications
+
+    def teardown():
+        henson.base.registry._applications = original
+    request.addfinalizer(teardown)
+
+    henson.base.registry._applications = []
+
+    return registry
 
 
 @pytest.fixture

--- a/tests/test_globals.py
+++ b/tests/test_globals.py
@@ -1,0 +1,15 @@
+import pytest
+
+from henson import Application, globals as globals_
+
+
+def test_current_application(mock_registry):
+    """Test that current_application is an Application."""
+    app = Application('testing')
+    assert app == globals_.current_application
+
+
+def test_current_application_runtimeerror():
+    """Test that accessing current application raises RuntimeError."""
+    with pytest.raises(RuntimeError):
+        globals_.current_application.settings


### PR DESCRIPTION
This is a convenience for accessing the current application from the
registry. It allows services and plugins to access it without having
knowledge of how Henson handles application registration.
