### PR TITLE
What rolls down stairs...

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -43,6 +43,28 @@ Quickstart
     if __name__ == '__main__':
         app.run_forever()
 
+Logging
+=======
+
+Henson applications provide a default logger. By default, the logger returned
+by calling :func:`logging.getLogger` will be used. The name of the application
+will be used to specify which logger to use. Any configuration needed should be
+done (e.g., :func:`logging.basicConfig`, :func:`logging.config.dictConfig`)
+should be done before the application is started.
+
+If you want to use a specific logger instance with your application, however,
+you can provide it when you instantiate the application::
+
+    app = Application(__name__, logger=logging.getLogger('specificlogger'))
+
+While this example is a bit contrived, this is useful if you want to use
+third-party loggers (e.g., `structlog <http://structlog.rtfd.org>`_) to handle
+your logging::
+
+    import structlog
+
+    app = Application(__name__, logger=structlog.get_logger())
+
 Contents:
 
 .. toctree::


### PR DESCRIPTION
While there is still work to be done, this is the beginning of logging
in Henson. Applications will now provided a logger that can be used to
send all messages through the same logger.

Some initial log messages are being added to `run_forever`. They will
track the startup and shutdown of the application (as info messages) as
well as any exceptions that occur trying to read a message. This will
probably be the extent of the messaging in `Application` with the
possible exception of debugging messages added to track the full startup
process.
