### PR TITLE
Add extension base class

### DIFF
--- a/henson/__init__.py
+++ b/henson/__init__.py
@@ -1,3 +1,4 @@
 """Henson."""
 
 from .base import Application  # NOQA
+from .extensions import Extension  # NOQA

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -1,0 +1,49 @@
+"""Extension base."""
+
+__all__ = ('Extension',)
+
+
+class Extension:
+
+    """A base class for Hension extensions.
+
+    Args:
+        app (optional): An application instance that has an attribute
+          named settings that contains a mapping of settings to interact
+          with a database.
+    """
+
+    def __init__(self, app=None):
+        """Initialize an instance of the extension.
+
+        If app is provided, init_app will also be called with the provided
+        application. Otherwise, init_app must be called with an application
+        explicitly before the extension's reference to an application is
+        usable.
+        """
+        self._app = None
+
+        if app:
+            self.init_app(app)
+
+    def init_app(self, app):
+        """Configure the application with the extension's default settings.
+
+        Args:
+            app: Application instance that has an attribute named
+              settings that contains a mapping of settings.
+        """
+        if hasattr(self, 'DEFAULT_SETTINGS'):
+            for key, value in self.DEFAULT_SETTINGS.items():
+                app.settings.setdefault(key, value)
+
+        self._app = app
+
+    @property
+    def app(self):
+        """Return the registered app."""
+        if not self._app:
+            raise RuntimeError(
+                'No application has been assigned to this instance. '
+                'init_app must be called before referencing instance.app.')
+        return self._app

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -3,6 +3,20 @@
 import pytest
 
 
+class Application:
+
+    """A stub application that can be used for testing.
+
+    Args:
+        **settings: Keyword arguments that will be used as settings.
+    """
+
+    def __init__(self, **settings):
+        """Initialize the instance."""
+        self.name = 'testing'
+        self.settings = settings
+
+
 @pytest.fixture
 def settings():
     """Create a configuration object."""
@@ -11,3 +25,9 @@ def settings():
         B = 2
 
     return Config
+
+
+@pytest.fixture
+def test_app():
+    """Return a test application."""
+    return Application()

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -1,0 +1,42 @@
+"""Test handling of apps."""
+
+import pytest
+
+from henson import Extension
+
+
+def test_app_access_with_app(test_app):
+    """Test that Extension.app returns the provided app."""
+    extension = Extension(test_app)
+    assert extension.app == test_app
+
+
+def test_app_access_with_init_app(test_app):
+    """Test that Extension.app returns an app set by init_app."""
+    extension = Extension()
+    extension.init_app(test_app)
+    assert extension.app == test_app
+
+
+def test_app_access_with_no_app_raises_runtimeerror():
+    """Test that Extension.app raises RuntimeError when there is no app."""
+    with pytest.raises(RuntimeError):
+        Extension().app
+
+
+def test_extension_without_default_settings(test_app):
+    """Test that an Extension without DEFAULT_SETTINGS doesn't affect app."""
+    class CustomExtension(Extension):
+        pass
+
+    CustomExtension(test_app)
+    assert test_app.settings == {}
+
+
+def test_extension_with_default_settings(test_app):
+    """Test that an Extension's DEFAULT_SETTINGS populate an app's settings."""
+    class CustomExtension(Extension):
+        DEFAULT_SETTINGS = {'foo': 'bar'}
+
+    CustomExtension(test_app)
+    assert test_app.settings == {'foo': 'bar'}


### PR DESCRIPTION
Centralizes core extension logic and testing and reduces boilerplate
required to implement new extensions.
