### PR TITLE
Add `pwd` to `sys.path` to improve service discoverability

### DIFF
--- a/henson/cli.py
+++ b/henson/cli.py
@@ -28,6 +28,11 @@ def run(application_path):
                                    'application_path must be of the form '
                                    'path.to.module:application_name')
 
+    # Add the present working directory to the import path so that
+    # services can be found without installing them to site-packages
+    # or modifying PYTHONPATH
+    sys.path.insert(0, '.')
+
     # Then, try to find an import loader for the import_path
     # NOTE: this is to handle the case where a module is found but not
     # importable because of dependency import errors (Python 3 only)


### PR DESCRIPTION
Currently, a service must reside within a directory on the `PYTHONPATH`
in order to be imported by the Henson CLI's `run` command. This can be
done in one of two ways: installing the service (i.e. copying it to
site-packages) or appending the present working directory to the
`PYTHONPATH` environment variable. By automatically adding `'.'` to
`sys.path`, the Henson can find and import the service by running
`henson run` from within the service's parent directory.

Prior art: many runners like this (e.g. those included by the Flask [0]
and Django[1] web frameworks) also do this for similar reasons.

[0] https://github.com/mitsuhiko/flask/blob/7f3867491570746a4c14bdaa5bd59ec1b64cbfea/flask/cli.py#L222
[1] https://docs.djangoproject.com/en/1.8/ref/django-admin/#django-admin-and-manage-py
