### PR TITLE
Add `--reloader` option to `henson run`

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -1,8 +1,16 @@
 Changelog
 =========
 
+Version 0.3.0
+-------------
+
+Release date TBD
+
+- Add ``--reloader`` option to ``henson run``
+
+
 Version 0.2.1
-+-------------
+-------------
 
 Released 2015-08-03
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,6 +23,8 @@ Quickstart
 
 .. code::
 
+    # file_printer.py3
+
     from henson import Application
 
     class FileConsumer:
@@ -40,15 +42,24 @@ Quickstart
     app.callback = callback
     app.consumer = FileConsumer(__file__)
 
-    if __name__ == '__main__':
-        app.run_forever()
-
 Running Applications
 ====================
 
-.. code::
+Henson provides a CLI command to run your applications. To run the application
+defined in the quickstart above, cd to the directory containing the module and
+run::
 
     $ henson run path.to.module:app_attribute
+
+When developing locally, applications often need to be restarted as changes are
+made. To make this easier, Henson provides a ``--reloader`` option to the
+``run`` command. With this option enabled, Henson will watch an application's
+root directory and restart the application automatically when changes are
+detected::
+
+    $ henson run file_printer:app --reloader
+
+.. note:: The ``--reloader`` option is not recommended for production use.
 
 Logging
 =======

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,9 @@ setup(
     version='0.3.0',
     packages=find_packages(exclude=['tests']),
     install_requires=[
+        # TODO: determine minimum versions for requirements
         'click',
+        'watchdog>=0.8.3',
     ],
     tests_require=[
         'tox',


### PR DESCRIPTION
`henson run module:app --reloader` will run a Henson application and
automatically reload and restart it when changes are detected within
that application's root directory. This removes the need for developers
to manually restart the runner process as they develop and make changes
to applications.
