### PR TITLE
Add docs-requirements.txt

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,0 +1,3 @@
+doc8
+sphinx
+sphinxcontrib-napoleon

--- a/tox.ini
+++ b/tox.ini
@@ -12,10 +12,7 @@ commands =
 [testenv:docs]
 basepython = python3.4
 skip_install = True
-deps =
-    doc8
-    sphinx
-    sphinxcontrib-napoleon
+deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/


### PR DESCRIPTION
Henson's docs require shinxcontrib-napoleon to build. ReadTheDocs is
able to build documentation using napoleon, but only if a requirements
file is provided. A new requirements file is added to allow ReadTheDocs
to build this documentation, and individual requirements specified in
tox.ini are hoisted and replaced with `-rdocs-requirements.txt` to avoid
duplication.
