### PR TITLE
Add application autodetection to run command

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -7,6 +7,9 @@ Version 0.3.0
 Release date TBD
 
 - Add ``--reloader`` option to ``henson run``
+- Automatically detect instances of Henson applications when running ``henson
+  run`` if no attribute name is specified and there exists only one instance of
+  an application in the loaded module
 
 
 Version 0.2.1

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -23,7 +23,7 @@ Quickstart
 
 .. code::
 
-    # file_printer.py3
+    # file_printer.py
 
     from henson import Application
 
@@ -49,7 +49,15 @@ Henson provides a CLI command to run your applications. To run the application
 defined in the quickstart above, cd to the directory containing the module and
 run::
 
-    $ henson run path.to.module:app_attribute
+    $ henson run file_printer
+
+If a module contains only one instance of a Henson
+:class:`~henson.base.Application`, ``henson run`` will automatically detect
+this and run it. If more than one application exists within the module, the
+desired application's name must be specified, e.g.  ``henson run
+file_printer:app``. This form always takes precedence over the former, and the
+henson cli will not attempt to fall back to an auto-detected application if
+there is a problem with the name specified.
 
 When developing locally, applications often need to be restarted as changes are
 made. To make this easier, Henson provides a ``--reloader`` option to the

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -65,9 +65,20 @@ def bad_mock_service(modules_tmpdir):
 def good_mock_service(modules_tmpdir):
     """Create a module for a fake service."""
     good_import = modules_tmpdir.join('good_import.py')
-    good_import.write(getsource(MockApplication))
     good_import.write('\n'.join((
         'from henson import Application',
         getsource(MockApplication),
         'app = MockApplication()',
+    )))
+
+
+@pytest.fixture
+def double_mock_service(modules_tmpdir):
+    """Create a module with two fake services."""
+    double_service = modules_tmpdir.join('double_service.py')
+    double_service.write('\n'.join((
+        'from henson import Application',
+        getsource(MockApplication),
+        'app1 = MockApplication()',
+        'app2 = MockApplication()',
     )))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -16,29 +16,28 @@ def test_run_without_app_path(click_runner):
     """Test that the run command fails without an application_path."""
     result = click_runner.invoke(run)
     assert result.exit_code != 0
-    assert 'Error: Missing argument "application_path".' in result.output
+    assert 'Missing argument "application_path".' in result.output
 
 
 def test_run_only_module(click_runner):
     """Test that the run command fails with a malformed application_path."""
     result = click_runner.invoke(run, ['mymodule'])
     assert result.exit_code != 0
-    assert ('Error: application_path must be of the form '
-            'path.to.module:application_name' in result.output)
+    assert 'Unable to find an import loader for mymodule' in result.output
 
 
 def test_run_failed_loader(click_runner):
     """Test that the run command fails with a module that is not found."""
     result = click_runner.invoke(run, ['mymodule:app'])
     assert result.exit_code != 0
-    assert 'Error: Unable to find an import loader' in result.output
+    assert 'Unable to find an import loader' in result.output
 
 
 def test_run_failed_import(click_runner, bad_mock_service):
     """Test that the run command fails on dependency import errors."""
     result = click_runner.invoke(run, ['bad_import:app'])
     assert result.exit_code != 0
-    assert 'Error: Unable to import bad_import' in result.output
+    assert isinstance(result.exception, ImportError)
 
 
 def test_run_attribute_error(click_runner):
@@ -47,15 +46,36 @@ def test_run_attribute_error(click_runner):
     # doesn't have an attribute called `app`.
     result = click_runner.invoke(run, ['logging:app'])
     assert result.exit_code != 0
-    assert "Error: 'module' object has no attribute 'app'" in result.output
+    assert isinstance(result.exception, AttributeError)
 
 
 def test_run_non_henson_app(click_runner):
     """Tests that the run command fails with the incorrect app type."""
     result = click_runner.invoke(run, ['logging:INFO'])
     assert result.exit_code != 0
-    assert ("Error: app must be an instance of a Henson application. Got "
+    assert ("app must be an instance of a Henson application. Got "
             "<class 'int'>" in result.output)
+
+
+def test_run_without_application(click_runner):
+    """Tests that the run command fails without an app name or instance."""
+    result = click_runner.invoke(run, ['logging'])
+    assert result.exit_code != 0
+    assert 'No Henson application found' in result.output
+
+
+def test_run_with_two_applications(click_runner, double_mock_service):
+    """Tests that the run command fails with ambiguous app choices."""
+    result = click_runner.invoke(run, ['double_service'])
+    assert result.exit_code != 0
+    assert 'More than one Henson application found' in result.output
+
+
+def test_run_app_autodetect(click_runner, good_mock_service):
+    """Tests that an app can be selected automatically."""
+    result = click_runner.invoke(run, ['good_import'])
+    assert result.exit_code == 0
+    assert 'Run, Forrest, run!' in result.output
 
 
 def test_run_forever(click_runner, good_mock_service):


### PR DESCRIPTION
Typically, a service built with Henson will have a single instance of an
application defined in a module. When using the run command, this
instance can be automatically chosen, removing the need to pass the
attribute name to `henson run`.

While adding this feature, some of `henson run`'s errors were made more
clear. Import and attribute errors are no longer hidden by the CLI and
bubble up.
