### PR TITLE
Add REQUIRED_SETTINGS attribute to the Extension class

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -10,7 +10,7 @@ Release date TBD
 - Automatically detect instances of Henson applications when running ``henson
   run`` if no attribute name is specified and there exists only one instance of
   an application in the loaded module
-
+- Add REQUIRED_SETTINGS functionality to the Extension class
 
 Version 0.2.1
 -------------

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -41,9 +41,23 @@ Henson provides a base class to make extension development easier.
                 self._connection = sqlite3.connect(conn_string)
             return self._connection
 
+The :class:`~henson.extensions.Extension` class provides two special attributes
+that are meant to be overridden:
+
+* :attr:`~henson.extensions.Extension.DEFAULT_SETTINGS` provides default
+  values to an application's settings during the ``init_app`` step. When a
+  value is used by an extension and has a sensible default, it should be stored
+  here (e.g. a database hostname).
+* :attr:`~henson.extensions.Extension.REQUIRED_SETTINGS` provides a list
+  of keys that are checked for existence during the ``init_app`` step. If one
+  or more required settings are not set on the application instance assigned to
+  the extension, a ``KeyError`` is raised.  Extensions should set this when a
+  value is required but has no default (e.g.  a database password).
+
 Available Extensions
 ====================
 
 * `Henson-Database <https://github.com/iheartradio/Henson-Database>`_
 * `Henson-Kafka <https://github.com/iheartradio/Henson-Kafka>`_
 * `Henson-Logging <https://github.com/iheartradio/Henson-Logging>`_
+* `Henson-SQS <https://github.com/iheartradio/Henson-SQS>`_

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -29,6 +29,32 @@ class Extension:
         if app:
             self.init_app(app)
 
+    @property
+    def DEFAULT_SETTINGS(self):  # noqa
+        """A ``dict`` of default settings for the extension.
+
+        When a setting is not specified by the application instance and
+        has a default specified, the default value will be used.
+        Extensions should define this where appropriate. Defaults to
+        ``{}``.
+        """
+        return {}
+
+    @property
+    def REQUIRED_SETTINGS(self):  # noqa
+        """An ``iterable`` of required settings for the extension.
+
+        When an extension has required settings that do not have default
+        values, their keys may be specified here. Upon extension
+        initialization, an exception will be raised if a value is not
+        set for each key specified in this list. Extensions should
+        define this where appropriate. Defaults to ``()``.
+
+
+        .. versionadded:: 0.3.0
+        """
+        return ()
+
     def init_app(self, app):
         """Configure the application with the extension's default settings.
 
@@ -36,9 +62,19 @@ class Extension:
             app: Application instance that has an attribute named
               settings that contains a mapping of settings.
         """
-        if hasattr(self, 'DEFAULT_SETTINGS'):
-            for key, value in self.DEFAULT_SETTINGS.items():
-                app.settings.setdefault(key, value)
+        for key, value in self.DEFAULT_SETTINGS.items():
+            app.settings.setdefault(key, value)
+
+        required_settings = set(self.REQUIRED_SETTINGS)
+        current_settings = set(app.settings.keys())
+        missing_settings = required_settings - current_settings
+        if missing_settings:
+            raise KeyError(
+                '{} requires the following missing settings: {}'.format(
+                    self.__class__.__name__,
+                    ', '.join(str(key) for key in missing_settings),
+                )
+            )
 
         self._app = app
 

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -40,3 +40,22 @@ def test_extension_with_default_settings(test_app):
 
     CustomExtension(test_app)
     assert test_app.settings == {'foo': 'bar'}
+
+
+def test_extension_required_settings_exception(test_app):
+    """Tests that init_app raises REQUIRED_SETTINGS exceptions."""
+    class CustomExtension(Extension):
+        REQUIRED_SETTINGS = ('foo', 'bar')
+
+    with pytest.raises(KeyError):
+        CustomExtension(test_app)
+
+
+def test_extension_with_required_settings(test_app):
+    """Tests that init_app doesn't raise REQUIRED_SETTINGS exceptions."""
+    class CustomExtension(Extension):
+        REQUIRED_SETTINGS = ('foo', 'bar')
+
+    test_app.settings['foo'] = 1
+    test_app.settings['bar'] = 2
+    CustomExtension(test_app)


### PR DESCRIPTION
A REQUIRED_SETTINGS attribute allows extensions to denote settings that
must exist on an application for the extension to function.
Additionally, documentation for the DEFAULT_SETTINGS attribute and a
link to the Henson-SQS extension are added.
