### PR TITLE
Remove the logger override

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ Version 0.4.0
 
 Released TBD
 
+- Remove argument to override application-level logger
+
 Version 0.3.0
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -72,24 +72,11 @@ detected::
 Logging
 =======
 
-Henson applications provide a default logger. By default, the logger returned
-by calling :func:`logging.getLogger` will be used. The name of the application
-will be used to specify which logger to use. Any configuration needed should be
-done (e.g., :func:`logging.basicConfig`, :func:`logging.config.dictConfig`)
-should be done before the application is started.
-
-If you want to use a specific logger instance with your application, however,
-you can provide it when you instantiate the application::
-
-    app = Application(__name__, logger=logging.getLogger('specificlogger'))
-
-While this example is a bit contrived, this is useful if you want to use
-third-party loggers (e.g., `structlog <http://structlog.rtfd.org>`_) to handle
-your logging::
-
-    import structlog
-
-    app = Application(__name__, logger=structlog.get_logger())
+Henson applications provide a default logger. The logger returned by calling
+:func:`logging.getLogger` will be used. The name of the application will be
+used to specify which logger to use. Any configuration needed should (e.g.,
+:func:`logging.basicConfig`, :func:`logging.config.dictConfig`) should be done
+before the application is started.
 
 Contents:
 


### PR DESCRIPTION
I had good intentions when I decided to add a logger override argument
to `Application`. Hindsight, though, is 20/20 and I feel it has just led
to more aggravation than good. The argument is being removed. All of
Henson's internal logging will be handled by the logger returned by
`getLogger`. Applications are free to use this logger or their own
(e.g., Henson-Logging).
