### PR TITLE
Add pre- and postprocessing callbacks

### DIFF
--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -1,0 +1,61 @@
+=========
+Callbacks
+=========
+
+Henson operates on messages through a series of callbacks. Each serves a unique
+purpose.
+
+``callback``
+============
+
+This is the only one of the callback settings that is required. Its purpose is
+to process the incoming message. If desired, it should return the result(s) of
+processing the message as an iterable.
+
+.. code::
+
+    def callback(application, message):
+        yield 'spam'
+
+    Application(..., callback=callback)
+
+``message_preprocessors``
+=========================
+
+This is a list of callbacks that are intended to modify the incoming message
+before it is passed to ``callback`` for processing.
+
+.. code::
+
+    def add_process_id(application, message):
+        message['pid'] = os.getpid()
+        return message
+
+    Application(..., message_preprocessors=[add_process_id])
+
+``result_postprocessors``
+=========================
+
+This is a list of callbacks are will operate on the result(s) of ``callback``.
+Each callback is applied to each result.
+
+.. code::
+
+    def store_result(application, result):
+        with open('/tmp/result', 'w') as f:
+            f.write(result)
+
+    Application(..., result_postprocessors=[store_result])
+
+``error_callback``
+==================
+
+This callback is called when an error occurs while trying to read the next
+message from the consumer.
+
+.. code::
+
+    def log_error(application, result):
+        logger.error('spam')
+
+    Application(..., error_callback=log_error)

--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,9 @@ Released TBD
 
 - Remove argument to override application-level logger
 - Improve test coverage
+- Add ``message_preprocessors`` to handle preprocessing incoming messages
+- Add ``result_postprocessors`` to handle postprocessing results of processing
+  the incoming messages
 
 Version 0.3.0
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -84,6 +84,7 @@ Contents:
    :maxdepth: 1
 
    interface
+   callbacks
    extensions
    api
    changes

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -6,7 +6,7 @@ from henson.base import Application
 
 
 def test_run_forever_consumer_is_none_typeerror():
-    """Test that TypeError is raised when the consumer is None."""
+    """Test that TypeError is raised if the consumer is None."""
     app = Application('testing', consumer=None)
     with pytest.raises(TypeError):
         app.run_forever()
@@ -14,7 +14,33 @@ def test_run_forever_consumer_is_none_typeerror():
 
 @pytest.mark.parametrize('callback', (None, '', False, 10))
 def test_run_forever_callback_not_callable_typerror(callback):
-    """Test that TypeError is raised when callback isn't callable."""
+    """Test that TypeError is raised if callback isn't callable."""
     app = Application('testing', consumer=[], callback=callback)
+    with pytest.raises(TypeError):
+        app.run_forever()
+
+
+@pytest.mark.parametrize('callback', (None, '', False, 10))
+def test_run_forever_message_preprocessor_not_callable_typeerror(callback):
+    """Test that TypeError is raised if preprocessor isn't callable."""
+    app = Application(
+        'testing',
+        consumer=[],
+        callback=lambda *x: None,
+        message_preprocessors=[callback],
+    )
+    with pytest.raises(TypeError):
+        app.run_forever()
+
+
+@pytest.mark.parametrize('callback', (None, '', False, 10))
+def test_run_forever_result_postprocessor_not_callable_typeerror(callback):
+    """Test that TypeError is raised if postprocessor isn't callable."""
+    app = Application(
+        'testing',
+        consumer=[],
+        callback=lambda *x: None,
+        result_postprocessors=[callback],
+    )
     with pytest.raises(TypeError):
         app.run_forever()


### PR DESCRIPTION
Applications may wish to use some sort of middleware to manipulate
incoming messages before they are passed into the application and the
results of processing them. To achieve this two new parameters are being
added to `Application`: `message_preprocessors` and
`result_postprocessors`. Each of these parameters takes a list of
callables that will be executed at the appropriate time.

Also, since there were none, some initial tests are being added to cover
`Application`. More of these will be needed.
