### PR TITLE
Catch the correct base exception

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -11,6 +11,8 @@ Released TBD
 - Add ``message_preprocessors`` to handle preprocessing incoming messages
 - Add ``result_postprocessors`` to handle postprocessing results of processing
   the incoming messages
+- Restructure exception catching to handle ``Exception`` and break on
+  ``BaseException``
 
 Version 0.3.0
 -------------

--- a/henson/base.py
+++ b/henson/base.py
@@ -88,14 +88,14 @@ class Application:
         while True:
             try:
                 message = next(messages)
-            except KeyboardInterrupt:
-                break
             except StopIteration:
                 continue
-            except BaseException:
+            except Exception:
                 self.logger.error('message.failed', exc_info=sys.exc_info())
                 if self.error_callback:
                     self.error_callback(self, message)
+            except BaseException:
+                break
             else:
                 self.logger.info('message.received')
 


### PR DESCRIPTION
Generally you want to use `Exception` when trying to catch all
exceptions. Very rarely do you ever want to use `BaseException`.

Note that it's even rarer that you should want to catch all exceptions.
In this case, however, we are catching them so they can be logged and
processed.
