### PR TITLE
Henson-Retry

### DIFF
--- a/docs/contrib.rst
+++ b/docs/contrib.rst
@@ -1,0 +1,12 @@
+====================
+``contrib`` Packages
+====================
+
+While it is possible to build your own plugins for Henson, the following is
+included:
+
+.. toctree::
+   :maxdepth: 1
+   :glob:
+
+   contrib/*

--- a/docs/contrib/retry.rst
+++ b/docs/contrib/retry.rst
@@ -1,0 +1,83 @@
+=====
+Retry
+=====
+
+Retry is a plugin to add the ability for Henson to automatically retry messages
+that fail to process.
+
+.. warning::
+
+   Retry registers itself as an error callback on the
+   :class:`~henson.base.Application` instance. When doing so, it inserts itself
+   at the beginning of the list of error callbacks. It does this so that it can
+   prevent other callbacks from running.
+
+   If you have an error callback that you want to run even when retrying a
+   message, make sure you register it *after* initializing Retry.
+
+Configuration
+=============
+
+Retry provides a couple settings to control how many times a message will be
+retried. ``RETRY_THESHOLD`` and ``RETRY_TIMEOUT`` work in tandem. If values are
+specified for both, whichever limit is reached first will cause Henson to stop
+retrying the message. By default, Henson will try forever (yes, this is
+literally insane).
+
++------------------+----------------------------------------------------------+
+| RETRY_BACKOFF    | If set to True, the delay between retry attempts will    |
+|                  | increase between each subsequent retry. Defaults to      |
+|                  | False.                                                   |
++------------------+----------------------------------------------------------+
+| RETRY_CALLBACK   | A callable that encapsulates the functionality needed to |
+|                  | retry the message. If no value is provided, a            |
+|                  | ``TypeError`` will be raised.                            |
++------------------+----------------------------------------------------------+
+| RETRY_EXCEPTIONS | An exception or tuple of exceptions that will cause      |
+|                  | Henson to retry the message.  Defaults to                |
+|                  | `RetryableException`.                                    |
++------------------+----------------------------------------------------------+
+| RETRY_DELAY      | The number of seconds to wait before scheduling a retry. |
+|                  | If ``RETRY_BACKOFF`` is set to True, the delay will      |
+|                  | increase between each retry. Defaults to 0.              |
++------------------+----------------------------------------------------------+
+| RETRY_THRESHOLD  | The maximum number of times that a Henson application    |
+|                  | will try to process a message before marking it as a     |
+|                  | failure. if set to 0, the message will not be retried.   |
+|                  | If set to None, the limit will be controlled by          |
+|                  | ``RETRY_TIMEOUT``. Defaults to None.                     |
++------------------+----------------------------------------------------------+
+| RETRY_TIMEOUT    | The maximum number of seconds during which a message can |
+|                  | be retried. If set to None, the limit will be controlled |
+|                  | by ``RETRY_THRESHOLD``. Defaults to None.                |
++------------------+----------------------------------------------------------+
+
+Usage
+=====
+
+Application definition::
+
+    from henson import Application
+    from henson.contrib.retry import Retry
+
+    def print_message(app, message):
+        print(message)
+
+    app = Application('retryable-application', callback=my_callback)
+    app.settings['RETRY_CALLBACK'] = print_message
+    Retry(app)
+
+Somwhere inside the application::
+
+   from henson.contrib.retry import RetryableException
+
+   def my_callback(app, message):
+       raise RetryableException
+
+API
+===
+
+.. autoclass:: henson.contrib.retry.Retry
+   :members:
+
+.. autoclass:: henson.contrib.retry.RetryableException

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -86,6 +86,7 @@ Contents:
    interface
    callbacks
    extensions
+   contrib
    api
    changes
 

--- a/henson/contrib/retry/__init__.py
+++ b/henson/contrib/retry/__init__.py
@@ -1,0 +1,150 @@
+"""Retry plugin for Henson.
+
+Retry is a plugin to add the ability for Henson to automatically retry
+messages that fail to process.
+
+.. versionadded:: 0.4.0
+"""
+
+import time
+
+from henson.extensions import Extension
+
+__all__ = ('Retry', 'RetryableException')
+
+
+def _exceeded_threshold(number_of_retries, maximum_retries):
+    """Return True if the number of retries has been exceeded.
+
+    Args:
+        number_of_retries (int): The number of retry attempts made
+            already.
+        maximum_retries (int): The maximum number of retry attempts to
+            make.
+
+    Returns:
+        bool: True if the maximum number of retry attempts have already
+            been made.
+    """
+    if maximum_retries is None:
+        # Retry forever.
+        return False
+
+    return number_of_retries >= maximum_retries
+
+
+def _exceeded_timeout(start_time, duration):
+    """Return True if the timeout has been exceeded.
+
+    Args:
+        start_time (int): The timestamp of the first retry attempt.
+        duration (int): The total number of seconds to retry for.
+
+    Returns:
+        bool: True if the timeout has passed.
+    """
+    if duration is None:
+        # Retry forever.
+        return False
+
+    # Duration is in seconds, not milliseconds like start_time.
+    return start_time + (duration * 1000) <= int(time.time())
+
+
+def _retry(app, message, exc):
+    """Retry the message.
+
+    An exception that is included as a retryable type will result in the
+    message being retried so long as the threshold and timeout haven't
+    been reached.
+
+    Args:
+        app (henson.Application): The current application.
+        message (dict): The message to be retried.
+        exc (Exception): The exception that caused processing the
+            message to fail.
+
+    Raises:
+        StopIteration: If the message is scheduled to be retried.
+    """
+    if not isinstance(exc, app.settings['RETRY_EXCEPTIONS']):
+        # If the exception raised isn't retryable, return control so the
+        # next error callback can be called.
+        return
+
+    retry_info = _retry_info(message)
+
+    threshold = app.settings['RETRY_THRESHOLD']
+    if _exceeded_threshold(retry_info['count'], threshold):
+        # If we've exceeded the number of times to retry the message,
+        # don't retry it again.
+        return
+
+    timeout = app.settings['RETRY_TIMEOUT']
+    if _exceeded_timeout(retry_info['start_time'], timeout):
+        # If we've gone past the time to stop retrying, don't retry it
+        # again.
+        return
+
+    retry_info['count'] += 1
+    message['_retry'] = retry_info
+
+    # TODO: Incorporate delay and backoff.
+    # Retry the message.
+    app.settings['RETRY_CALLBACK'](app, message)
+
+    # If the exception was retryable, none of the other callbacks should
+    # execute.
+    raise StopIteration
+
+
+def _retry_info(message):
+    """Return the retry attempt information.
+
+    Args:
+        message (dict): The message to be retried.
+
+    Returns:
+        dict: The retry attempt information.
+    """
+    info = message.get('_retry', {})
+    info.setdefault('count', 0)
+    info.setdefault('start_time', int(time.time()))
+    return info
+
+
+class RetryableException(Exception):
+    """Exception to be raised when a message should be retried."""
+
+
+class Retry(Extension):
+    """A class that adds retries to an application."""
+
+    DEFAULT_SETTINGS = {
+        'RETRY_BACKOFF': False,
+        'RETRY_DELAY': 0,
+        'RETRY_EXCEPTIONS': RetryableException,
+        'RETRY_THRESHOLD': None,
+        'RETRY_TIMEOUT': None,
+    }
+
+    REQUIRED_SETTINGS = (
+        'RETRY_CALLBACK',
+    )
+
+    def init_app(self, app):
+        """Initialize an ``Application`` instance.
+
+        Args:
+            app (~henson.base.Application): Application instance to be
+                initialized.
+        """
+        super().init_app(app)
+
+        if not callable(app.settings['RETRY_CALLBACK']):
+            raise TypeError('The retry callback is not callable.')
+
+        # The retry callback should be executed before all other
+        # callbacks. This will ensure that retryable exceptions are
+        # retried.
+        app.error_callbacks.insert(0, _retry)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -21,6 +21,8 @@ class MockApplication(Application):
         self.name = 'testing'
         self.settings = settings
 
+        self.error_callbacks = []
+
     def run_forever(self):
         print('Run, Forrest, run!')
 
@@ -39,6 +41,14 @@ def settings():
 def test_app():
     """Return a test application."""
     return MockApplication()
+
+
+@pytest.fixture
+def callback():
+    """Return a stubbed callback function."""
+    def _inner(*args):
+        pass
+    return _inner
 
 
 @pytest.fixture

--- a/tests/contrib/test_retry.py
+++ b/tests/contrib/test_retry.py
@@ -1,0 +1,106 @@
+"""Test for henson.contrib.retry."""
+
+import time
+
+import pytest
+
+from henson.contrib import retry
+
+
+@pytest.mark.parametrize('number_of_retries, threshold, expected', [
+    # Retry forever.
+    (0, None, False),
+    (1, None, False),
+    # Don't retry.
+    (0, 0, True),
+    (1, 0, True),
+    # Rrtry.
+    (0, 1, False),
+    (1, 2, False),
+])
+def test_exceeded_threshold(number_of_retries, threshold, expected):
+    """Test _exceeded_threshold."""
+    actual = retry._exceeded_threshold(number_of_retries, threshold)
+    assert actual == expected
+
+
+@pytest.mark.parametrize('offset, duration, expected', [
+    # Retry forever.
+    (0, None, False),  # now
+    (10000, None, False),  # 10 seconds ago
+    # Don't retry.
+    (0, 0, True),
+    (10000, 0, True),
+    # Retry.
+    (1000, 10, False),
+    (10000, 20, False),
+])
+def test_exceeded_timeout(offset, duration, expected):
+    """Test _exceeded_timeout."""
+    start_time = int(time.time()) - offset
+    actual = retry._exceeded_timeout(start_time, duration)
+    assert actual == expected
+
+
+def test_callback_insertion(test_app, callback):
+    """Test that the callback is properly registered."""
+    # Add an error callback before registering Retry.
+    def original_callback(*args):
+        pass
+    test_app.error_callbacks.append(original_callback)
+
+    # Register Retry.
+    test_app.settings['RETRY_CALLBACK'] = callback
+    retry.Retry(test_app)
+
+    assert test_app.error_callbacks[0] is retry._retry
+
+
+def test_callback_exceeds_threshold(test_app, callback):
+    """Test that callback doesn't run when the threshold is exceeded."""
+    # Create a function that sets a flag indicating it's been called.
+    original_callback_called = False
+
+    def original_callback(*args):
+        nonlocal original_callback_called
+        original_callback_called = True
+
+    test_app.error_callbacks.append(original_callback)
+
+    test_app.settings['RETRY_CALLBACK'] = callback
+    test_app.settings['RETRY_THRESHOLD'] = 0
+
+    for cb in test_app.error_callbacks:
+        cb(test_app, {}, retry.RetryableException())
+
+    assert original_callback_called
+
+
+def test_callback_exceeds_timeout(test_app, callback):
+    """Test that callback doesn't run when the timeout is exceeded."""
+    # Create a function that sets a flag indicating it's been called.
+    original_callback_called = False
+
+    def original_callback(*args):
+        nonlocal original_callback_called
+        original_callback_called = True
+
+    test_app.error_callbacks.append(original_callback)
+
+    test_app.settings['RETRY_CALLBACK'] = callback
+    test_app.settings['RETRY_TIMEOUT'] = 0
+
+    for cb in test_app.error_callbacks:
+        cb(test_app, {}, retry.RetryableException())
+
+    assert original_callback_called
+
+
+def test_callback_prevents_others(test_app, callback):
+    """Test that the callback blocks other callbacks."""
+    test_app.settings['RETRY_CALLBACK'] = callback
+    retry.Retry(test_app)
+
+    with pytest.raises(StopIteration):
+        for cb in test_app.error_callbacks:
+            cb(test_app, {}, retry.RetryableException())


### PR DESCRIPTION
Retry is a plugin for Henson that will allow an application to
 automatically retry a message that failed to process. It does this by
 registering an error callback that runs before all others. The callback,
 however, will only run when the exception is of a supported type and the
 retry attempt threshold and timeout haven't been reached.

 This is the first of what could be many contrib packages for Henson.

 As part of this change, the control flow of `Application.run_forever` is
 being modified to support multiple error callbacks. These callbacks will be
 called when a message fails to process, rather than when Henson fails to
 receive a message from the consumer.
