### PR TITLE
Process messages asynchronously

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -6,6 +6,8 @@ Version 0.5.0
 
 Released TBD
 
+- Use ``asyncio`` to process messages asynchronously (*Backwards Incompatible*)
+
 Version 0.4.0
 -------------
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -25,6 +25,8 @@ Quickstart
 
     # file_printer.py
 
+    import asyncio
+
     from henson import Application
 
     class FileConsumer:
@@ -35,8 +37,14 @@ Quickstart
             with open(self.filename) as f:
                 yield from f
 
+        @asyncio.coroutine
+        def read(self):
+            return next(self)
+
+    @asyncio.coroutine
     def callback(app, data):
         print(app.name, 'received:', data)
+        return data
 
     app = Application(__name__)
     app.callback = callback

--- a/docs/interface.rst
+++ b/docs/interface.rst
@@ -3,15 +3,15 @@ Consumer Interface
 ==================
 
 To work with Henson, a consumer must conform to the Consumer Interface. To
-conform to the interface, the object must be iterable. It can be a built-in
-type, a generator, a custom class with an ``__iter__`` method, etc.
+conform to the interface, the object must expose a coroutine named ``read``.
 
 Below is a sample implementation.
 
 .. code::
 
-    class FileConsumer:
+    import asyncio
 
+    class FileConsumer:
         """Read files from a file."""
 
         def __init__(self, filename):
@@ -22,9 +22,7 @@ Below is a sample implementation.
             with open(self.filename) as f:
                 yield from f
 
-This can be simplified to just use the stream object directly.
-
-.. code::
-
-    with open(filename) as f:
-        # f can be used as the consumer.
+        @asyncio.coroutine
+        def read(self):
+            """Return the next line in the file."""
+            return next(self)

--- a/henson/base.py
+++ b/henson/base.py
@@ -1,5 +1,6 @@
 """Implementation of the service."""
 
+import asyncio
 import logging
 import sys
 
@@ -22,28 +23,35 @@ class Application:
           iterable and yields instances of any type that is supported by
           ``callback``. While this isn't required, it must be provided
           before the application can be run.
-        callback (callable, optional): A callable object that takes two
-          arguments, an instance of this class and the (possibly)
-          preprocessed incoming message.  While this isn't required, it
-          must be provided before the application can be run.
-        error_callbacks (List[callable], optional): A list of callable
-          objects that take three arguments: an instance of this class,
-          the incoming message, and the exception that was raised. These
-          callbacks will be called any time there is an exception while
-          reading a message from the queue.
-        message_preprocessors (List[callable], optional): A list of
-          callable objects that take two arguments: an instance of this
-          class and the incoming message. These callbacks will be called
-          first for each incoming message and its return value will be
-          passed to ``callback``.
-        result_postprocessors (List[callable], optional): A list of
-          callable objects that takes two arguments: an instance of this
-          class and the each result of ``callback``.
+        callback (asyncio.coroutine, optional): A callable object that
+          takes two arguments, an instance of this class and the
+          (possibly) preprocessed incoming message.  While this isn't
+          required, it must be provided before the application can be
+          run.
+        error_callbacks (List[asyncio.coroutine], optional): A list of
+          callable objects that take three arguments: an instance of
+          this class, the incoming message, and the exception that was
+          raised. These callbacks will be called any time there is an
+          exception while reading a message from the queue.
+        message_preprocessors (List[asyncio.coroutine], optional): A
+          list of callable objects that take two arguments: an instance
+          of this class and the incoming message. These callbacks will
+          be called first for each incoming message and its return value
+          will be passed to ``callback``.
+        result_postprocessors (List[asyncio.coroutine], optional): A
+          list of callable objects that takes two arguments: an instance
+          of this class and the each result of ``callback``.
+
+    .. versionchanged:: 0.5.0
+
+        ``callback``, ``error_callbacks``, ``message_preprocessors``,
+        and ``result_postprocessors`` now require coroutines.
 
     .. versionchanged:: 0.4.0
-       The ``message_preprocessors`` and ``result_postprocessors``
-       parameters have been added to optionally preprocess an incoming
-       msesage and postprocess all results.
+
+        The ``message_preprocessors`` and ``result_postprocessors``
+        parameters have been added to optionally preprocess an incoming
+        msesage and postprocess all results.
     """
 
     def __init__(self, name, settings=None, *, consumer=None, callback=None,
@@ -62,69 +70,148 @@ class Application:
 
         self.logger = logging.getLogger(self.name)
 
-    def run_forever(self):
+    def run_forever(self, num_workers=1):
         """Consume from the consumer until interrupted.
+
+        Args:
+            num_workers (int): The number of asynchronous tasks to use
+              to process messages received through the consumer.
+              Defaults to 1.
 
         Raises:
             TypeError: If the consumer is None or the callback isn't
               callable.
+
+        .. versionchanged:: 0.5.0
+
+            Messages are now processed asynchronously. The
+            ``num_workers`` parameter has been added to control how many
+            futures are used to process them.
         """
         if self.consumer is None:
             raise TypeError('The consumer cannot be None.')
 
-        if not callable(self.callback):
-            raise TypeError('The specified callback is not callable.')
+        _is_coroutine = asyncio.iscoroutinefunction
 
-        if not all(callable(cb) for cb in self.message_preprocessors):
-            raise TypeError(
-                'Message preprocessors must be callable.')
+        if not _is_coroutine(self.callback):
+            raise TypeError('The specified callback is not a coroutine.')
 
-        if not all(callable(cb) for cb in self.result_postprocessors):
-            raise TypeError(
-                'Result postprocessors must be callable.')
+        if not all(_is_coroutine(cb) for cb in self.message_preprocessors):
+            raise TypeError('Message preprocessors must be coroutines.')
 
-        if not all(callable(cb) for cb in self.error_callbacks):
-            raise TypeError(
-                'Error callbacks must be callable.')
+        if not all(_is_coroutine(cb) for cb in self.result_postprocessors):
+            raise TypeError('Result postprocessors must be coroutines.')
+
+        if not all(_is_coroutine(cb) for cb in self.error_callbacks):
+            raise TypeError('Error callbacks must be coroutines.')
 
         self.logger.info('application.started')
 
-        messages = iter(self.consumer)
-        while True:
-            try:
-                message = next(messages)
-            except BaseException:
-                self.logger.error('message.failed', exc_info=sys.exc_info())
-                break
-            else:
-                self.logger.info('message.received')
+        loop = asyncio.get_event_loop()
 
-                for preprocess in self.message_preprocessors:
-                    message = preprocess(self, message)
-                    self.logger.info('message.preprocessed')
+        # Create an asynchronous queue to pass the messages from the
+        # consumer to the processor. The queue should hold one message
+        # for each processing task.
+        queue = asyncio.Queue(maxsize=num_workers)
 
-                try:
-                    results = self.callback(self, message)
-                except Exception as e:
-                    self.logger.error(
-                        'message.failed', exc_info=sys.exc_info())
-                    for callback in self.error_callbacks:
-                        # Any callback can prevent execution of further
-                        # callbacks by raising StopIteration.
-                        try:
-                            callback(self, message, e)
-                        except StopIteration:
-                            break
-                else:
-                    if results is not None:
-                        # TODO: Evaluate this further. What are the pros
-                        # and cons of operating over multiple results
-                        # versus keeping it just one. As we look into
-                        # asyncio, there may be benefits to yielding
-                        # from callback rather than returning.
-                        for result in results:
-                            for postprocess in self.result_postprocessors:
-                                result = postprocess(self, result)
-                                self.logger.info('result.postprocessed')
+        # Create a future for the consumer.
+        consumer = asyncio.async(self._consume(queue))
+
+        # Create futures to process each message received by the
+        # consumer. The loop should wait until they are done.
+        _tasks = [
+            asyncio.async(self._process(consumer, queue))
+            for _ in range(num_workers)]
+        tasks = asyncio.gather(*_tasks)
+        asyncio.wait(tasks)
+
+        try:
+            # Run the loop forever.
+            loop.run_forever()
+        except BaseException as e:
+            self.logger.error(e)
+
+            # If something log wrong, cancel the consumer and restart
+            # the loop. This will allow the futures to process all of
+            # the messages in the queue and then exit cleanly.
+            consumer.cancel()
+            loop.run_until_complete(tasks)
+
+            # Check for any exceptions that may have been raised by the
+            # futures.
+            self.logger.error(tasks.exception())
+        finally:
+            # Clean up after ourselves.
+            loop.close()
 
         self.logger.info('application.stopped')
+
+    @asyncio.coroutine
+    def _consume(self, queue):
+        """Read in incoming messages.
+
+        Args:
+            queue (asyncio.Queue): Any messages read in by the consumer
+                will be added to the queue to share them with any future
+                processing the messages.
+
+        .. versionadded:: 0.5.0
+        """
+        while True:
+            # Read messages and add them to the queue.
+            value = yield from self.consumer.read()
+            yield from queue.put(value)
+
+    @asyncio.coroutine
+    def _process(self, task, queue):
+        """Process incoming messages.
+
+        Args:
+            task (asyncio.tasks.Task): The task populating ``queue``.
+              The function will exit when it's been cancelled.
+            queue (asyncio.Queue): A queue containing incoming messages
+              to be processed.
+
+        .. versionadded:: 0.5.0
+        """
+        while True:
+            if queue.empty():
+                # If there aren't any messages in the queue, check to
+                # see if the consumer has been cancelled. If it has,
+                # exit. Otherwise yield control back to the event loop
+                # and then try again.
+                if task.cancelled():
+                    break
+
+                yield from asyncio.sleep(0.1)
+                continue
+
+            message = yield from queue.get()
+
+            for preprocess in self.message_preprocessors:
+                message = yield from preprocess(self, message)
+                self.logger.info('message.preprocessed')
+
+            try:
+                results = yield from self.callback(self, message)
+            except Exception as e:
+                self.logger.error(
+                    'message.failed', exc_info=sys.exc_info())
+                for callback in self.error_callbacks:
+                    # Any callback can prevent execution of further
+                    # callbacks by raising StopIteration.
+                    try:
+                        yield from callback(self, message, e)
+                    except StopIteration:
+                        break
+            else:
+                if results is not None:
+                    # TODO: Evaluate this further. What are the pros
+                    # and cons of operating over multiple results
+                    # versus keeping it just one. As we look into
+                    # asyncio, there may be benefits to yielding
+                    # from callback rather than returning.
+                    for result in results:
+                        for postprocess in self.result_postprocessors:
+                            result = yield from postprocess(self, result)
+                            self.logger.info('result.postprocessed')

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -10,9 +10,6 @@ class Extension:
         app (optional): An application instance that has an attribute
           named settings that contains a mapping of settings to interact
           with a database.
-
-
-    .. versionadded:: 0.2.0
     """
 
     def __init__(self, app=None):
@@ -48,9 +45,6 @@ class Extension:
         initialization, an exception will be raised if a value is not
         set for each key specified in this list. Extensions should
         define this where appropriate. Defaults to ``()``.
-
-
-        .. versionadded:: 0.3.0
         """
         return ()
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,15 +1,15 @@
 """Test the application registry."""
 
+import asyncio
 from inspect import getsource
-import pytest
 
 from click.testing import CliRunner
+import pytest
 
 from henson import Application
 
 
 class MockApplication(Application):
-
     """A stub application that can be used for testing.
 
     Args:
@@ -25,6 +25,32 @@ class MockApplication(Application):
 
     def run_forever(self):
         print('Run, Forrest, run!')
+
+
+class MockConsumer:
+    """A stub consumer that can be used for testing."""
+
+    @asyncio.coroutine
+    def read(self):
+        """Return an item."""
+        return 1
+
+
+@pytest.fixture
+def callback():
+    """Return a stubbed callback function."""
+    def _inner(*args):
+        pass
+    return _inner
+
+
+@pytest.fixture
+def coroutine():
+    """Return a coroutine function."""
+    @asyncio.coroutine
+    def _inner(*args, **kwargs):
+        pass
+    return _inner
 
 
 @pytest.fixture
@@ -44,11 +70,9 @@ def test_app():
 
 
 @pytest.fixture
-def callback():
-    """Return a stubbed callback function."""
-    def _inner(*args):
-        pass
-    return _inner
+def test_consumer():
+    """Return a test consumer."""
+    return MockConsumer()
 
 
 @pytest.fixture

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -1,46 +1,86 @@
 """Test Application."""
 
+import asyncio
+
 import pytest
 
 from henson.base import Application
 
 
-def test_run_forever_consumer_is_none_typeerror():
-    """Test that TypeError is raised if the consumer is None."""
+def test_consume(event_loop, test_consumer):
+    """Test Application._consume."""
+    queue = asyncio.Queue(maxsize=1)
+
+    app = Application('testing', consumer=test_consumer)
+
+    # Eventually stop the event loop so that we can check the contents
+    # of the queue.
+    def stop_loop():
+        event_loop.stop()
+    event_loop.call_soon(stop_loop)
+
+    asyncio.async(app._consume(queue))
+
+    event_loop.run_forever()
+
+    # The size of the queue won't ever be larger than 1 because of the
+    # maxsize argument.
+    assert queue.qsize() == 1
+
+
+def test_consumer_is_none_typeerror():
+    """Test TypeError is raised if the consumer is None."""
     app = Application('testing', consumer=None)
     with pytest.raises(TypeError):
         app.run_forever()
 
 
-@pytest.mark.parametrize('callback', (None, '', False, 10))
-def test_run_forever_callback_not_callable_typerror(callback):
-    """Test that TypeError is raised if callback isn't callable."""
+@pytest.mark.parametrize('callback', (None, '', False, 10, sum))
+def test_callback_not_coroutine_typerror(callback):
+    """Test TypeError is raised if callback isn't a coroutine."""
     app = Application('testing', consumer=[], callback=callback)
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         app.run_forever()
+    assert 'specified callback' in str(e.value).lower()
 
 
-@pytest.mark.parametrize('callback', (None, '', False, 10))
-def test_run_forever_message_preprocessor_not_callable_typeerror(callback):
-    """Test that TypeError is raised if preprocessor isn't callable."""
+@pytest.mark.parametrize('error_callback', (None, '', False, 10, sum))
+def test_error_callback_not_coroutine_typeerror(error_callback, coroutine):
+    """Test TypeError is raised if error callback isn't a coroutine."""
     app = Application(
         'testing',
         consumer=[],
-        callback=lambda *x: None,
-        message_preprocessors=[callback],
+        callback=coroutine,
+        error_callbacks=[error_callback],
     )
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         app.run_forever()
+    assert 'error callbacks' in str(e.value).lower()
 
 
-@pytest.mark.parametrize('callback', (None, '', False, 10))
-def test_run_forever_result_postprocessor_not_callable_typeerror(callback):
-    """Test that TypeError is raised if postprocessor isn't callable."""
+@pytest.mark.parametrize('preprocess', (None, '', False, 10, sum))
+def test_message_preprocessor_not_coroutine_typeerror(preprocess, coroutine):
+    """Test TypeError is raised if preprocessor isn't a coroutine."""
     app = Application(
         'testing',
         consumer=[],
-        callback=lambda *x: None,
-        result_postprocessors=[callback],
+        callback=coroutine,
+        message_preprocessors=[preprocess],
     )
-    with pytest.raises(TypeError):
+    with pytest.raises(TypeError) as e:
         app.run_forever()
+    assert 'message preprocessors' in str(e.value).lower()
+
+
+@pytest.mark.parametrize('postprocess', (None, '', False, 10, sum))
+def test_result_postprocessor_not_coroutine_typeerror(postprocess, coroutine):
+    """Test TypeError is raised if postprocessor isn't a coroutine."""
+    app = Application(
+        'testing',
+        consumer=[],
+        callback=coroutine,
+        result_postprocessors=[postprocess],
+    )
+    with pytest.raises(TypeError) as e:
+        app.run_forever()
+    assert 'result postprocessors' in str(e.value).lower()

--- a/tox.ini
+++ b/tox.ini
@@ -5,6 +5,7 @@ envlist = docs,pep8,py35,py34
 deps =
     coverage
     pytest
+    pytest-asyncio
 commands =
     python -m coverage run -m pytest --strict {posargs: tests}
     python -m coverage report -m --include="henson/*"


### PR DESCRIPTION
We've decided to make Henson process messages asynchronously. Since 3.4
is the lowest support version of Python, asynchronous support is being
added through `asyncio`.

When Henson runs an application is will create one future for the
consumer. The consumer needs to expose a coroutine named `read`
(**note** this is a backwards incompatible change). The coroutine should
return the next message to be processed. (Internally, the message will
be placed on an asynchronous queue that will be read by the processing
futures.)

`Application.run_forever` is gaining a new argument named `num_workers`.
This represents the number of futures that Henson will start to process
messages read in through the consumer. The `callback` and any callables
provided for `error_callbacks`, `message_preprocessors`, and
`result_postprocessors` must be coroutines.

These changes also simplify the flow used inside `run_forever` and allow
for much cleaner error handling.

To round things off, the documentation is being updated to account for
the new consumer interface.

This should be considered a first pass and not a stable implementation.
