### PR TITLE
Improve test coverage

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,5 @@
+[report]
+exclude_lines =
+    if __name__ == '__main__'
+    def __repr__
+    def __str__

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py35,py34
+envlist = docs,pep8,py34,py35
 
 [testenv]
 deps =


### PR DESCRIPTION
While there isn't any value in improving test coverage for the sake of
reporting a higher percentage, there is value in adding tests for
untested code. It can both give more confidence when changing code later
on and lead to changes that make the code easier to test.

The biggest hole in the test coverage was `Application.run_forever`.
Adding test coverage for it also led to separate methods for
postprocessing results and applying callbacks.

 A final change being made is the introduction of the `loop` argument to
`run_forever`. Henson has no opinion about which event loop to use. It
just uses the loop returned to it by `asyncio.get_event_loop`. There may
be times when a user already has a loop that they'd like Henson to use.
This new argument allows them to do that. If no value is provided, the
original behavior is used.
