### PR TITLE
Only allow versions of click prior to 6.0

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,11 @@ setup(
     packages=find_packages(exclude=['tests']),
     install_requires=[
         # TODO: determine minimum versions for requirements
-        'click',
+        # Version 6 of click changed the signature of BadOptionUsage,
+        # breaking version 5.x compatible code. While we decide how best
+        # to handle this in Henson, click is being pinned to older
+        # versions of click.
+        'click<6.0',
         'watchdog>=0.8.3',
     ],
     tests_require=[


### PR DESCRIPTION
Version 6.0 of click introduced a change that breaks some of the CLI
tests. Until we're able to determine the root of problem, Henson will
require a previous version of click.
