### PR TITLE
Correctly check docstrings in pep8 tox environment

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -20,7 +20,7 @@ commands =
 [testenv:pep8]
 basepython = python3.5
 deps =
-    flake8-docstrings
+    flake8-docstrings==0.2.1.post1
     pep8-naming
 commands =
     flake8 henson


### PR DESCRIPTION
PEP 257 requires that there be no blank lines between a class's
declaration and its docstring. The pep257 library includes a check for a
blank line (D203) but excludes it from the list of checks to run when
using `pep257.check`. flake8-docstrings 0.2.2 introduced a change that
stopped using this function and instead used the `PEP257Checker` class.
Unfortunately this class requires that all registered checks, include
D203, pass.

Until either pep257 or flake8-docstrings has been updated to address
this, the version of the latter shall remain pinned at the last release
to use `pep257.check`.
