### PR TITLE
Add support for henson run app:app_factory

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -65,7 +65,11 @@ this and run it. If more than one application exists within the module, the
 desired application's name must be specified, e.g.  ``henson run
 file_printer:app``. This form always takes precedence over the former, and the
 henson cli will not attempt to fall back to an auto-detected application if
-there is a problem with the name specified.
+there is a problem with the name specified. If the attribute specified by the
+name after ``:`` is callable, ``henson run`` will call it and use the returned
+value as the application. Any callable specified this way should require no
+arguments and return an instance of an :class:`~henson.base.Application`.
+Autodiscovery of callables that return applications is not currently supported.
 
 When developing locally, applications often need to be restarted as changes are
 made. To make this easier, Henson provides a ``--reloader`` option to the

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -52,6 +52,11 @@ def run(application_path, reloader):
     try:
         app_name = application_path_parts.pop()
         app = getattr(module, app_name)
+        # If the attribute specified by app_name is a callable, assume
+        # it is an application factory and call it to get an instance of
+        # a Henson application.
+        if callable(app):
+            app = app()
         # Fail if the attribute specified is not a Henson application
         if not isinstance(app, Application):
             raise click.BadOptionUsage(


### PR DESCRIPTION
It's sometimes useful to use application factories rather than defining
applications directly. This change allows `henson run` to call the
application factory if it's the target of the command and run the return
value (a Henson `Application`).

Fixes #51.
