### PR TITLE
Reorganize test fixtures

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,9 +1,7 @@
 """Test the application registry."""
 
 import asyncio
-from inspect import getsource
 
-from click.testing import CliRunner
 import pytest
 
 from henson import Application
@@ -37,14 +35,6 @@ class MockConsumer:
 
 
 @pytest.fixture
-def callback():
-    """Return a stubbed callback function."""
-    def _inner(*args):
-        pass
-    return _inner
-
-
-@pytest.fixture
 def coroutine():
     """Return a coroutine function."""
     @asyncio.coroutine
@@ -73,46 +63,3 @@ def test_app():
 def test_consumer():
     """Return a test consumer."""
     return MockConsumer()
-
-
-@pytest.fixture
-def click_runner():
-    """Return a click CLI runner."""
-    return CliRunner()
-
-
-@pytest.fixture
-def modules_tmpdir(tmpdir, monkeypatch):
-    """Add a temporary directory for modules to sys.path."""
-    tmp = tmpdir.mkdir('tmp_modules')
-    monkeypatch.syspath_prepend(str(tmp))
-    return tmp
-
-
-@pytest.fixture
-def bad_mock_service(modules_tmpdir):
-    """Create a module for a fake service that cannot be imported."""
-    modules_tmpdir.join('bad_import.py').write('import not_a_real_module')
-
-
-@pytest.fixture
-def good_mock_service(modules_tmpdir):
-    """Create a module for a fake service."""
-    good_import = modules_tmpdir.join('good_import.py')
-    good_import.write('\n'.join((
-        'from henson import Application',
-        getsource(MockApplication),
-        'app = MockApplication()',
-    )))
-
-
-@pytest.fixture
-def double_mock_service(modules_tmpdir):
-    """Create a module with two fake services."""
-    double_service = modules_tmpdir.join('double_service.py')
-    double_service.write('\n'.join((
-        'from henson import Application',
-        getsource(MockApplication),
-        'app1 = MockApplication()',
-        'app2 = MockApplication()',
-    )))

--- a/tests/contrib/test_retry.py
+++ b/tests/contrib/test_retry.py
@@ -7,6 +7,14 @@ import pytest
 from henson.contrib import retry
 
 
+@pytest.fixture
+def callback():
+    """Return a stubbed callback function."""
+    def _inner(*args):
+        pass
+    return _inner
+
+
 @pytest.mark.parametrize('number_of_retries, threshold, expected', [
     # Retry forever.
     (0, None, False),


### PR DESCRIPTION
With the number of fixtures declared in `conftests.py`, we've decided
that module-specific fixtures should be defined directly in the module.
If the fixture ever has a need outside the module, it can be moved.

The fixtures for the CLI tests are being moved into the CLI test module.
Some of the tests require the source of `MockApplication`. An instance
of the class is provided through the `test_app` fixture; its source can
be obtained from the instance's type.

The `callback` fixture is mostly leftover from prior to the introduction
of `asyncio` and is currently only used by the Henson-Retry tests. It's
being moved to the retry module until it is removed entirely.

References #58
