### PR TITLE
Register callbacks, now with startup and teardown

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -26,28 +26,17 @@ class Application:
             by ``callback``. While this isn't required, it must be
             provided before the application can be run.
         callback (Optional[asyncio.coroutine]): A callable object that
-            takes two arguments, an instance of this class and the
-            (possibly) preprocessed incoming message.  While this isn't
-            required, it must be provided before the application can be
-            run.
-        error_callbacks (Optional[List[asyncio.coroutine]]): A list of
-            callable objects that take three arguments: an instance of
-            this class, the incoming message, and the exception that was
-            raised. These callbacks will be called any time there is an
-            exception while reading a message from the queue.
-        message_preprocessors (Optional[List[asyncio.coroutine]]): A
-            list of callable objects that take two arguments: an
-            instance of this class and the incoming message. These
-            callbacks will be called first for each incoming message and
-            its return value will be passed to ``callback``.
-        result_postprocessors (Optional[List[asyncio.coroutine]]): A
-            list of callable objects that takes two arguments: an
-            instance of this class and the each result of ``callback``.
+            takes two arguments, an instance of
+            :class:`henson.base.Application` and the (possibly)
+            preprocessed incoming message.  While this isn't required,
+            it must be provided before the application can be run.
 
     .. versionchanged:: 0.5.0
 
         ``callback``, ``error_callbacks``, ``message_preprocessors``,
-        and ``result_postprocessors`` now require coroutines.
+        and ``result_postprocessors`` now require coroutines, with all
+        but ``callback`` being removed from ``Application.__init__`` in
+        favor of decorators.
 
     .. versionchanged:: 0.4.0
 
@@ -56,9 +45,7 @@ class Application:
         msesage and postprocess all results.
     """
 
-    def __init__(self, name, settings=None, *, consumer=None, callback=None,
-                 error_callbacks=None, message_preprocessors=None,
-                 result_postprocessors=None):
+    def __init__(self, name, settings=None, *, consumer=None, callback=None):
         """Initialize the class."""
         self.name = name
 
@@ -69,13 +56,121 @@ class Application:
 
         # Callbacks
         self.callback = callback
-        self.error_callbacks = error_callbacks or []
-        self.message_preprocessors = message_preprocessors or []
-        self.result_postprocessors = result_postprocessors or []
+        self._callbacks = {
+            'error_callbacks': [],
+            'message_preprocessors': [],
+            'result_postprocessors': [],
+            'startup_callbacks': [],
+            'teardown_callbacks': [],
+        }
 
         self.consumer = consumer
 
         self.logger = logging.getLogger(self.name)
+
+    def application_startup(self, callback):
+        """Register a startup callback.
+
+        Args:
+            callback (asyncio.coroutine): A callable object that takes
+                an instance of :class:`~henson.base.Application` as its
+                only argument. It will be called once when the
+                application first starts up.
+
+        Returns:
+            asyncio.coroutine: The callback.
+
+        Raises:
+            TypeError: If the callback isn't a coroutine.
+
+        .. versionadded:: 0.5.0
+        """
+        self._register_callback(callback, 'startup_callbacks')
+        return callback
+
+    def application_teardown(self, callback):
+        """Register a teardown callback.
+
+        Args:
+            callback (asyncio.coroutine): A callable object that takes
+                an instance of :class:`~henson.base.Application` as its
+                only argument. It will be called once when the
+                application is shutting down.
+
+        Returns:
+            asyncio.coroutine: The callback.
+
+        Raises:
+            TypeError: If the callback isn't a coroutine.
+
+        .. versionadded:: 0.5.0
+        """
+        self._register_callback(callback, 'teardown_callbacks')
+        return callback
+
+    def error_callback(self, callback):
+        """Register an error callback.
+
+        Args:
+            callback (asyncio.coroutine): A callable object that takes
+                three arguments: an instance of
+                :class:`henson.base.Application`, the incoming message,
+                and the exception that was raised. It will be called any
+                time there is an exception while reading a message from
+                the queue.
+
+        Returns:
+            asyncio.coroutine: The callback.
+
+        Raises:
+            TypeError: If the callback isn't a coroutine.
+
+        .. versionadded:: 0.5.0
+        """
+        self._register_callback(callback, 'error_callbacks')
+        return callback
+
+    def message_preprocessor(self, callback):
+        """Register a message preprocessing callback.
+
+        Args:
+            callback (asyncio.coroutine): A callable object that takes
+                two arguments: an instance of
+                :class:`henson.base.Application` and the incoming
+                message. It will be called for each incoming message
+                with its result being passed to ``callback``.
+
+        Returns:
+            asyncio.coroutine: The callback.
+
+        Raises:
+            TypeError: If the callback isn't a coroutine.
+
+        .. versionadded:: 0.5.0
+        """
+        self._register_callback(callback, 'message_preprocessors')
+        return callback
+
+    def result_postprocessor(self, callback):
+        """Register a result postprocessing callback.
+
+        Args:
+            callback (asyncio.coroutine): A callable object that takes
+                two arguments: an instance of
+                :class:`henson.base.Application` and a result of
+                processing the incoming message. It will be called for
+                each result returned from ``callback``.
+
+        Returns:
+            asyncio.coroutine: The callback.
+
+        Raises:
+            TypeError: If the callback isn't a coroutine.
+
+        .. versionadded:: 0.5.0
+        """
+        self._register_callback(callback, 'result_postprocessors')
+        return callback
 
     def run_forever(self, num_workers=1, loop=None):
         """Consume from the consumer until interrupted.
@@ -90,8 +185,8 @@ class Application:
                 will be used.
 
         Raises:
-            TypeError: If the consumer is None or the callback isn't
-                callable.
+            TypeError: If the consumer is None or the callback isn't a
+                coroutine.
 
         .. versionchanged:: 0.5.0
 
@@ -100,59 +195,73 @@ class Application:
             futures are used to process them.
         """
         if self.consumer is None:
-            raise TypeError('The consumer cannot be None.')
+            raise TypeError("The Application's consumer cannot be None.")
 
-        _is_coroutine = asyncio.iscoroutinefunction
-
-        if not _is_coroutine(self.callback):
-            raise TypeError('The specified callback is not a coroutine.')
-
-        if not all(_is_coroutine(cb) for cb in self.message_preprocessors):
-            raise TypeError('Message preprocessors must be coroutines.')
-
-        if not all(_is_coroutine(cb) for cb in self.result_postprocessors):
-            raise TypeError('Result postprocessors must be coroutines.')
-
-        if not all(_is_coroutine(cb) for cb in self.error_callbacks):
-            raise TypeError('Error callbacks must be coroutines.')
-
-        self.logger.info('application.started')
+        if not asyncio.iscoroutinefunction(self.callback):
+            raise TypeError("The Application's callback must be a coroutine.")
 
         # Use the specified event loop, otherwise use the default one.
         loop = loop or asyncio.get_event_loop()
 
+        # Start the application.
+        tasks = [
+            asyncio.async(callback(self), loop=loop) for callback in
+            self._callbacks['startup_callbacks']
+        ]
+        future = asyncio.gather(*tasks, loop=loop)
+        loop.run_until_complete(future)
+
+        self.logger.info('application.started')
+
         # Create an asynchronous queue to pass the messages from the
         # consumer to the processor. The queue should hold one message
         # for each processing task.
-        queue = asyncio.Queue(maxsize=num_workers)
+        queue = asyncio.Queue(maxsize=num_workers, loop=loop)
 
-        # Create a future for the consumer.
-        consumer = asyncio.async(self._consume(queue))
+        # Create a future to control consumption and create a task for
+        # the consumer to run in.
+        consumer = asyncio.Future()
+        loop.create_task(self._consume(queue, consumer))
 
-        # Create futures to process each message received by the
-        # consumer. The loop should wait until they are done.
-        _tasks = [
-            asyncio.async(self._process(consumer, queue))
-            for _ in range(num_workers)]
-        tasks = asyncio.gather(*_tasks)
-        asyncio.wait(tasks)
+        # Create tasks to process each message received by the
+        # consumer and wrap them inside a future. When the loop stops
+        # running it should be restarted and wait until the future is
+        # done.
+        tasks = [
+            asyncio.async(self._process(consumer, queue), loop=loop)
+            for _ in range(num_workers)
+        ]
+        future = asyncio.gather(*tasks, loop=loop)
 
         try:
-            # Run the loop forever.
-            loop.run_forever()
+            # Run the loop until the consumer says to stop.
+            loop.run_until_complete(consumer)
         except BaseException as e:
             self.logger.error(e)
 
-            # If something log wrong, cancel the consumer and restart
-            # the loop. This will allow the futures to process all of
-            # the messages in the queue and then exit cleanly.
+            # If something went wrong, cancel the consumer. This will
+            # alert the processors to stop once the queue is empty.
             consumer.cancel()
-            loop.run_until_complete(tasks)
+        finally:
+            # Run the loop until the future completes. This will allow
+            # the tasks to finish processing all of the messages in the
+            # queue and then exit cleanly.
+            loop.run_until_complete(future)
 
             # Check for any exceptions that may have been raised by the
-            # futures.
-            self.logger.error(tasks.exception())
-        finally:
+            # tasks inside the future.
+            exc = future.exception()
+            if exc:
+                self.logger.error(exc)
+
+            # Teardown
+            tasks = [
+                asyncio.async(callback(self)) for callback in
+                self._callbacks['teardown_callbacks']
+            ]
+            future = asyncio.gather(*tasks)
+            loop.run_until_complete(future)
+
             # Clean up after ourselves.
             loop.close()
 
@@ -194,20 +303,31 @@ class Application:
         return value
 
     @asyncio.coroutine
-    def _consume(self, queue):
+    def _consume(self, queue, future):
         """Read in incoming messages.
+
+        Messages will be read from the consumer until it raises an
+        :class:`~henson.exceptions.Abort` exception.
 
         Args:
             queue (asyncio.Queue): Any messages read in by the consumer
                 will be added to the queue to share them with any future
                 processing the messages.
+            future (asyncio.Future): When the consumer tells the
+                application to stop, this future will be cancelled.
 
         .. versionadded:: 0.5.0
         """
         while True:
             # Read messages and add them to the queue.
-            value = yield from self.consumer.read()
-            yield from queue.put(value)
+            try:
+                value = yield from self.consumer.read()
+            except Abort:
+                self.logger.info('consumer.aborted')
+                future.cancel()
+                return
+            else:
+                yield from queue.put(value)
 
     @asyncio.coroutine
     def _process(self, task, queue):
@@ -224,10 +344,10 @@ class Application:
         while True:
             if queue.empty():
                 # If there aren't any messages in the queue, check to
-                # see if the consumer has been cancelled. If it has,
-                # exit. Otherwise yield control back to the event loop
-                # and then try again.
-                if task.cancelled():
+                # see if the consumer is done. If it is, exit.
+                # Otherwise yield control back to the event loop and
+                # then try again.
+                if task.done():
                     break
 
                 yield from asyncio.sleep(self.settings['SLEEP_TIME'])
@@ -237,7 +357,7 @@ class Application:
 
             try:
                 message = yield from self._apply_callbacks(
-                    self.message_preprocessors, message)
+                    self._callbacks['message_preprocessors'], message)
                 self.logger.info('message.preprocessed')
 
                 results = yield from self.callback(self, message)
@@ -246,7 +366,7 @@ class Application:
             except Exception as e:
                 self.logger.error(
                     'message.failed', exc_info=sys.exc_info())
-                for callback in self.error_callbacks:
+                for callback in self._callbacks['error_callbacks']:
                     # Any callback can prevent execution of further
                     # callbacks by raising StopIteration.
                     try:
@@ -276,7 +396,39 @@ class Application:
         for result in results:
             try:
                 yield from self._apply_callbacks(
-                    self.result_postprocessors, result)
+                    self._callbacks['result_postprocessors'], result)
                 self.logger.info('result.postprocessed')
             except Abort as e:
                 yield from self._abort(e)
+
+    def _register_callback(self, callback, callback_container):
+        """Register a callback.
+
+        Args:
+            callback (asyncio.coroutine): The callback to register.
+            callback_container (str): The name of the container onto
+                which to append the callback.
+
+        Raises:
+            TypeError: If the callback isn't a coroutine.
+
+        .. versionadded:: 0.5.0
+        """
+        if not asyncio.iscoroutinefunction(callback):
+            raise TypeError('The callback must be a coroutine.')
+
+        self._callbacks[callback_container].append(callback)
+
+        self.logger.info(
+            'callback.registered',
+            type=callback_container,
+            name=callback.__qualname__,
+        )
+
+    def _teardown(self, future, loop):
+        """Tear down the application."""
+        tasks = [
+            asyncio.async(callback(self)) for callback in
+            self._callbacks['teardown_callbacks']]
+        future = asyncio.gather(*tasks)
+        loop.run_until_complete(future)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,6 +5,7 @@ import asyncio
 import pytest
 
 from henson import Application
+from henson.exceptions import Abort
 
 
 class MockApplication(Application):
@@ -31,6 +32,21 @@ class MockConsumer:
     @asyncio.coroutine
     def read(self):
         """Return an item."""
+        return 1
+
+
+class MockAbortingConsumer:
+    """A stub consumer that will raise Abort."""
+
+    _run = False
+
+    @asyncio.coroutine
+    def read(self):
+        """Return an item."""
+        if self._run:
+            raise Abort('testing', {})
+
+        self._run = True
         return 1
 
 
@@ -77,3 +93,9 @@ def test_app():
 def test_consumer():
     """Return a test consumer."""
     return MockConsumer()
+
+
+@pytest.fixture
+def test_consumer_with_abort():
+    """Return a test consumer."""
+    return MockAbortingConsumer()

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -45,9 +45,11 @@ def test_abort_preprocessor(event_loop, cancelled_future, queue):
     app = Application(
         'testing',
         callback=callback,
-        message_preprocessors=[preprocess1, preprocess2],
-        result_postprocessors=[postprocess],
     )
+
+    app.message_preprocessor(preprocess1)
+    app.message_preprocessor(preprocess2)
+    app.result_postprocessor(postprocess)
 
     event_loop.run_until_complete(app._process(cancelled_future, queue))
 
@@ -82,8 +84,9 @@ def test_abort_callback(event_loop, cancelled_future, queue):
     app = Application(
         'testing',
         callback=callback,
-        result_postprocessors=[postprocess],
     )
+
+    app.result_postprocessor(postprocess)
 
     event_loop.run_until_complete(app._process(cancelled_future, queue))
 
@@ -122,8 +125,10 @@ def test_abort_postprocess(event_loop, cancelled_future, queue):
     app = Application(
         'testing',
         callback=callback,
-        result_postprocessors=[postprocess1, postprocess2],
     )
+
+    app.result_postprocessor(postprocess1)
+    app.result_postprocessor(postprocess2)
 
     event_loop.run_until_complete(app._process(cancelled_future, queue))
 


### PR DESCRIPTION
Henson would benefit from callbacks that can be run when an application
starts up and tears itself down (e.g., opening and closing connections).
As more types of callbacks are added , the signature for `Application`'s
initializer grows harder to read. Rather than continuing to add new
callbacks this way, all callbacks will now be registered through
instance methods. These methods can also be used as decorators.

The callback registration methods are:
- `application_startup`
- `application_teardown`
- `message_preprocessor`
- `result_postprocessor`
- `error_callback`

Additionally, some changes are being made to the control flow of
`run_forever` to accommodate its expanded functionality. The two most
notable changes are the explicit passing of a `loop` argument to pretty
much anything that accepts it and a change to the signature of
`_consume` to accept a future that it can cancel when the consumer
raises an `Abort` exception.

Fixes #53
