### PR TITLE
Link to the Python 3.5 documentation

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -293,4 +293,4 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3.4', None)}
+intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}


### PR DESCRIPTION
Henson should always link to the documentation for the most recent
supported version of its dependencies.
