### PR TITLE
Move location of version information

### DIFF
--- a/henson/__init__.py
+++ b/henson/__init__.py
@@ -1,8 +1,6 @@
 """Henson."""
 
-from pkg_resources import get_distribution
-
 from .base import Application  # NOQA
 from .extensions import Extension  # NOQA
 
-__version__ = get_distribution(__package__).version
+__version__ = '0.5.0'

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,10 @@
 from setuptools import find_packages, setup
 
+from henson import __version__
+
 setup(
     name='Henson',
-    version='0.5.0',
+    version=__version__,
     packages=find_packages(exclude=['tests']),
     install_requires=[
         # TODO: determine minimum versions for requirements


### PR DESCRIPTION
Currently, Henson must be installed to provide version information. This
is problematic when developing Henson (i.e. populating
`henson.__version__` causes errors). Version information is still
stored in only one location, but it it being moved to within the package
to address this issue.
