### PR TITLE
Update Henson-Retry to work with Henson 0.5

### DIFF
--- a/docs/contrib/retry.rst
+++ b/docs/contrib/retry.rst
@@ -13,7 +13,8 @@ that fail to process.
    prevent other callbacks from running.
 
    If you have an error callback that you want to run even when retrying a
-   message, make sure you register it *after* initializing Retry.
+   message, you will need to manually inject it into the list of error
+   callbacks *after* initializing Retry.
 
 Configuration
 =============
@@ -29,8 +30,8 @@ literally insane).
 |                  | increase between each subsequent retry. Defaults to      |
 |                  | False.                                                   |
 +------------------+----------------------------------------------------------+
-| RETRY_CALLBACK   | A callable that encapsulates the functionality needed to |
-|                  | retry the message. If no value is provided, a            |
+| RETRY_CALLBACK   | A coroutine that encapsulates the functionality needed   |
+|                  | to retry the message. If no value is provided, a         |
 |                  | ``TypeError`` will be raised.                            |
 +------------------+----------------------------------------------------------+
 | RETRY_EXCEPTIONS | An exception or tuple of exceptions that will cause      |
@@ -60,7 +61,7 @@ Application definition::
     from henson import Application
     from henson.contrib.retry import Retry
 
-    def print_message(app, message):
+    async def print_message(app, message):
         print(message)
 
     app = Application('retryable-application', callback=my_callback)
@@ -71,7 +72,7 @@ Somwhere inside the application::
 
    from henson.contrib.retry import RetryableException
 
-   def my_callback(app, message):
+   async def my_callback(app, message):
        raise RetryableException
 
 API

--- a/henson/base.py
+++ b/henson/base.py
@@ -394,16 +394,14 @@ class Application:
             except Abort as e:
                 yield from self._abort(e)
             except Exception as e:
-                self.logger.error('message.failed', extra={
-                    'exc_info': sys.exc_info(),
-                })
+                self.logger.error('message.failed', exc_info=sys.exc_info())
 
                 for callback in self._callbacks['error_callbacks']:
                     # Any callback can prevent execution of further
-                    # callbacks by raising StopIteration.
+                    # callbacks by raising Abort.
                     try:
                         yield from callback(self, message, e)
-                    except StopIteration:
+                    except Abort:
                         break
             else:
                 yield from self._postprocess_results(results)

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -17,10 +17,8 @@ class MockApplication(Application):
 
     def __init__(self, **settings):
         """Initialize the instance."""
-        self.name = 'testing'
+        super().__init__('testing')
         self.settings = settings
-
-        self.error_callbacks = []
 
     def run_forever(self, num_workers=1, loop=None):
         """Run the instance."""


### PR DESCRIPTION
Henson-Retry is being updated to use coroutines. (This will make
implementing the delay easier since a non-blocking sleep can be used.)
It's also being updated to raise `henson.exceptions.Abort` rather than
`StopIteration`. This requires an update to `henson.base.Application`
and introduces a new test. This test caught an error in how exceptions
are logged.

The way callbacks are registered has changed, so that's being updated as
well. This will need to be updated when the callback decorator names are
finalized.

References #73

Closes #58
