### PR TITLE
Rename callback registers

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -8,6 +8,10 @@ Released TBD
 
 - Use ``asyncio`` to process messages asynchronously (*Backwards Incompatible*)
 - Add ``Abort`` to allow for a coroutine to cancel processing of a message
+- Add support for application ``startup`` and ``teardown`` callbacks
+- Add support for ``message_acknowledgement`` callbacks to acknowledge incoming
+  messages
+- Update callback register names (*Backwards Incompatible*)
 
 Version 0.4.0
 -------------

--- a/henson/contrib/retry/__init__.py
+++ b/henson/contrib/retry/__init__.py
@@ -150,4 +150,4 @@ class Retry(Extension):
         # The retry callback should be executed before all other
         # callbacks. This will ensure that retryable exceptions are
         # retried.
-        app._callbacks['error_callbacks'].insert(0, _retry)
+        app._callbacks['error'].insert(0, _retry)

--- a/tests/contrib/test_retry.py
+++ b/tests/contrib/test_retry.py
@@ -47,7 +47,7 @@ def test_exceeded_timeout(offset, duration, expected):
 def test_callback_insertion(test_app, coroutine):
     """Test that the callback is properly registered."""
     # Add an error callback before registering Retry.
-    @test_app.error_callback
+    @test_app.error
     @asyncio.coroutine
     def original_callback(*args):
         pass
@@ -56,7 +56,7 @@ def test_callback_insertion(test_app, coroutine):
     test_app.settings['RETRY_CALLBACK'] = coroutine
     retry.Retry(test_app)
 
-    assert test_app._callbacks['error_callbacks'][0] is retry._retry
+    assert test_app._callbacks['error'][0] is retry._retry
 
 
 @pytest.mark.asyncio
@@ -65,7 +65,7 @@ def test_callback_exceeds_threshold(test_app, coroutine):
     # Create a function that sets a flag indicating it's been called.
     original_callback_called = False
 
-    @test_app.error_callback
+    @test_app.error
     @asyncio.coroutine
     def original_callback(*args):
         nonlocal original_callback_called
@@ -74,7 +74,7 @@ def test_callback_exceeds_threshold(test_app, coroutine):
     test_app.settings['RETRY_CALLBACK'] = coroutine
     test_app.settings['RETRY_THRESHOLD'] = 0
 
-    for cb in test_app._callbacks['error_callbacks']:
+    for cb in test_app._callbacks['error']:
         yield from cb(test_app, {}, retry.RetryableException())
 
     assert original_callback_called
@@ -86,7 +86,7 @@ def test_callback_exceeds_timeout(test_app, coroutine):
     # Create a function that sets a flag indicating it's been called.
     original_callback_called = False
 
-    @test_app.error_callback
+    @test_app.error
     @asyncio.coroutine
     def original_callback(*args):
         nonlocal original_callback_called
@@ -95,7 +95,7 @@ def test_callback_exceeds_timeout(test_app, coroutine):
     test_app.settings['RETRY_CALLBACK'] = coroutine
     test_app.settings['RETRY_TIMEOUT'] = 0
 
-    for cb in test_app._callbacks['error_callbacks']:
+    for cb in test_app._callbacks['error']:
         yield from cb(test_app, {}, retry.RetryableException())
 
     assert original_callback_called
@@ -108,5 +108,5 @@ def test_callback_prevents_others(test_app, coroutine):
     retry.Retry(test_app)
 
     with pytest.raises(Abort):
-        for cb in test_app._callbacks['error_callbacks']:
+        for cb in test_app._callbacks['error']:
             yield from cb(test_app, {}, retry.RetryableException())

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -67,11 +67,11 @@ def test_callback_not_coroutine_typerror(callback):
 
 
 @pytest.mark.parametrize('error_callback', (None, '', False, 10, sum))
-def test_error_callback_not_coroutine_typeerror(error_callback):
+def test_error_not_coroutine_typeerror(error_callback):
     """Test TypeError is raised if error callback isn't a coroutine."""
     app = Application('testing')
     with pytest.raises(TypeError):
-        app.error_callback(error_callback)
+        app.error(error_callback)
 
 
 @pytest.mark.parametrize('acknowledgement', (None, '', False, 10, sum))
@@ -160,7 +160,7 @@ def test_startup_not_coroutine_typeerror(startup):
     """Test TypeError is raised if startup isn't a coroutine."""
     app = Application('testing')
     with pytest.raises(TypeError):
-        app.application_startup(startup)
+        app.startup(startup)
 
 
 @pytest.mark.parametrize('teardown', (None, '', False, 10, sum))
@@ -168,7 +168,7 @@ def test_teardown_not_coroutine_typeerror(teardown):
     """Test TypeError is raised if teardown isn't a coroutine."""
     app = Application('testing')
     with pytest.raises(TypeError):
-        app.application_teardown(teardown)
+        app.teardown(teardown)
 
 
 def test_run_forever(event_loop, test_consumer_with_abort):
@@ -192,7 +192,7 @@ def test_run_forever(event_loop, test_consumer_with_abort):
         callback=callback,
     )
 
-    @app.application_startup
+    @app.startup
     @asyncio.coroutine
     def startup(app):
         nonlocal startup_called
@@ -217,7 +217,7 @@ def test_run_forever(event_loop, test_consumer_with_abort):
         nonlocal acknowledgement_called
         acknowledgement_called = True
 
-    @app.application_teardown
+    @app.teardown
     @asyncio.coroutine
     def teardown(app):
         nonlocal teardown_called

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -105,14 +105,14 @@ def test_abort_error(event_loop, cancelled_future, queue):
 
     app = Application('testing', callback=callback)
 
-    @app.error_callback
+    @app.error
     @asyncio.coroutine
     def error1(app, message, exc):
         nonlocal error1_called
         error1_called = True
         raise exceptions.Abort('testing', message)
 
-    @app.error_callback
+    @app.error
     @asyncio.coroutine
     def error2(app, message, exc):
         nonlocal error2_called


### PR DESCRIPTION
Three of the callback registers are being renamed. `application_startup`
will be known as `startup`, `application_teardown` will be known as
`teardown`, and `error_callback` will be known as `error`. This makes
their names less redundant and easier to read.

The callback documentation is being updated to not only reflect these
new names, but callbacks that have been added and other changes
introduced as part of Henson 0.5.

References #69

Closes #73
