### PR TITLE
Expand quickstart example application

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -27,7 +27,7 @@ Quickstart
 
     import asyncio
 
-    from henson import Application
+    from henson import Application, Abort
 
     class FileConsumer:
         def __init__(self, filename):
@@ -37,18 +37,37 @@ Quickstart
             with open(self.filename) as f:
                 yield from f
 
-        @asyncio.coroutine
-        def read(self):
+        async def read(self):
             return next(self)
 
-    @asyncio.coroutine
-    def callback(app, data):
+    async def callback(app, data):
+        """Print the data retrieved from the file consumer."""
         print(app.name, 'received:', data)
         return data
 
-    app = Application(__name__)
-    app.callback = callback
-    app.consumer = FileConsumer(__file__)
+    app = Application(
+        __name__,
+        callback=callback,
+        consumer=FileConsumer(__file__),
+    )
+
+    @app.startup
+    async def print_header(app):
+        """Print a header for the file being processed."""
+        print('# Begin processing', app.consumer.filename)
+
+    @app.teardown
+    async def print_footer(app):
+        """Print a footer for the file being processed."""
+        print('# Done processing', app.consumer.filename)
+
+    @app.message_preprocessor
+    async def remove_comments(app, line):
+        """Abort processing of comments (lines that start with #)."""
+        if line.strip().startswith('#'):
+            raise Abort('Line is a comment', line)
+        return line
+
 
 Running Applications
 ====================


### PR DESCRIPTION
Add startup, teardown, and message_preprocessor callbacks to the example
application. The quickstart does not cover all of Henson's
functionality, but it now contains a more realistic application.

References #69.
