### PR TITLE
Fix application callback syntax

### DIFF
--- a/docs/callbacks.rst
+++ b/docs/callbacks.rst
@@ -15,7 +15,7 @@ processing the message as an iterable.
 .. code::
 
     async def callback(application, message):
-        yield 'spam'
+        return ['spam']
 
     Application('name', callback=callback)
 


### PR DESCRIPTION
During the change to coroutine callbacks, the example callback
function's declaration was updated, but its body was not. `yield`
cannot be used within an async function, so the example must `return`
instead.
