### PR TITLE
Update extension docs

### DIFF
--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -58,6 +58,5 @@ Available Extensions
 ====================
 
 * `Henson-Database <https://github.com/iheartradio/Henson-Database>`_
-* `Henson-Kafka <https://github.com/iheartradio/Henson-Kafka>`_
 * `Henson-Logging <https://github.com/iheartradio/Henson-Logging>`_
 * `Henson-SQS <https://github.com/iheartradio/Henson-SQS>`_

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -60,8 +60,8 @@ class Extension:
         required settings.
 
         Args:
-            app (Optional[henson.base.Application]): An application
-                instance that will be initialized.
+            app (henson.base.Application): An application instance that
+                will be initialized.
         """
         for key, value in self.DEFAULT_SETTINGS.items():
             app.settings.setdefault(key, value)


### PR DESCRIPTION
- Remove incorrect use of `Optional` in `henson.Extension.init_app`.
- Remove `Henson-Kafka` from list of supported extensions (there are
  no current plans for a public release of this plugin).
