### PR TITLE
Shut down on consumer exceptions

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -353,6 +353,11 @@ class Application:
                 self.logger.info('consumer.aborted')
                 future.cancel()
                 return
+            except Exception as e:
+                # If the consumer fails, set the exception on the future
+                # so that the loop will stop running and the application
+                # will shut down.
+                future.set_exception(e)
             else:
                 yield from queue.put(value)
 

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -51,6 +51,30 @@ def test_consume(event_loop, test_consumer, cancelled_future):
     assert queue.qsize() == 1
 
 
+def test_consumer_exception(event_loop):
+    """Test that the application stops after a consumer exception."""
+    consumer_called = False
+    callback_called = False
+
+    class Consumer:
+        @asyncio.coroutine
+        def read(self):
+            nonlocal consumer_called
+            consumer_called = True
+            raise Exception()
+
+    @asyncio.coroutine
+    def callback(app, message):
+        nonlocal callback_called
+        callback_called = True
+
+    app = Application('testing', consumer=Consumer(), callback=callback)
+    app.run_forever(loop=event_loop)
+
+    assert consumer_called
+    assert not callback_called
+
+
 def test_consumer_is_none_typeerror():
     """Test TypeError is raised if the consumer is None."""
     app = Application('testing', consumer=None)


### PR DESCRIPTION
Applications are controlled by a future that can be cancelled when a
consumer aborts. Any other exception, however, doesn't cause the future
to stop. This will do that by setting the future's exception to the
exception raised by the consumer.
