### PR TITLE
Add debug mode

### DIFF
--- a/docs/changes.rst
+++ b/docs/changes.rst
@@ -12,6 +12,8 @@ Released TBD
 - Add support for ``message_acknowledgement`` callbacks to acknowledge incoming
   messages
 - Update callback register names (*Backwards Incompatible*)
+- Add debug mode, available through ``--debug`` on the command line, the
+  `DEBUG` setting, and as an argument to ``Application.run_forever``
 
 Version 0.4.0
 -------------

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -114,6 +114,9 @@ detected::
 
 .. note:: The ``--reloader`` option is not recommended for production use.
 
+It's also possible to enable Henson's `debug mode`_ through the ``--debug``
+option.
+
 Logging
 =======
 
@@ -122,6 +125,22 @@ Henson applications provide a default logger. The logger returned by calling
 used to specify which logger to use. Any configuration needed should (e.g.,
 :func:`logging.basicConfig`, :func:`logging.config.dictConfig`) should be done
 before the application is started.
+
+.. _debug mode:
+
+Debug Mode
+==========
+
+Debugging with asyncio can be tricky. Henson provides a debug mode that will
+enable asyncio's debug mode as well as enable debugging information through
+Henson's logger.
+
+Debug mode can be enabled through a configuration setting::
+
+    app.settings['DEBUG'] = True
+
+or by providing a value for ``debug`` when calling
+:meth:`~henson.base.Application.run_forever`.
 
 Contents:
 

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -15,7 +15,7 @@ from . import __version__
 from .base import Application
 
 
-def run(application_path, reloader=False, workers=1):
+def run(application_path, reloader=False, workers=1, debug=False):
     """Import and run an application.
 
     Args:
@@ -27,6 +27,8 @@ def run(application_path, reloader=False, workers=1):
             Defaults to False.
         workers (Optional[int]): How many async workers the application
             should use to process messages. Defaults to 1.
+        debug (Optional[bool]): Whether or not to run the application
+            with debug mode enabled. Defaults to False.
     """
     # Add the present working directory to the import path so that
     # services can be found without installing them to site-packages


### PR DESCRIPTION
Debugging with asyncio can be tricky. Without enabling its debug
mode--this is generally done by setting the `PYTHONASYNCIODEBUG`
environment variable--exceptions inside tasks can be swallowed.

To make it easier to see this information, a debug mode is being added
to Henson. It can be enabled through the command line, the call to
`run_forever`, and the `DEBUG` application configuration setting.

Closes #85
