### PR TITLE
Fix logging KeyError

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -320,7 +320,7 @@ class Application:
         stack = traceback.extract_tb(tb, 1)[-1]
         self.logger.info('callback.aborted', extra={
             'exception': exc,
-            'message': exc.message,
+            'exception_message': exc.message,
             'aborted_by': stack,
         })
 


### PR DESCRIPTION
Calls to `logger.info` with an `extra` dict containing a key of
`'message'` raise a `KeyError`. To allow the `_abort` method to
work properly, a different key must be used.
