### PR TITLE
Fix reloader behavior

### DIFF
--- a/henson/cli.py
+++ b/henson/cli.py
@@ -2,6 +2,7 @@
 
 """Collection of Henson CLI tasks."""
 
+import asyncio
 from importlib import find_loader, import_module
 import os
 import sys
@@ -113,9 +114,10 @@ def run(application_path, reloader=False, workers=1, debug=False):
 
         # Create observer and runner threads
         observer = Observer()
+        loop = asyncio.new_event_loop()
         runner = Thread(
             target=app.run_forever,
-            kwargs={'num_workers': workers},
+            kwargs={'num_workers': workers, 'loop': loop},
         )
 
         # This function is called by watchdog event handler when changes

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -127,7 +127,8 @@ def test_message_acknowledgement_original_message(event_loop, coroutine,
         nonlocal actual
         actual = message
 
-    event_loop.run_until_complete(app._process(cancelled_future, queue))
+    event_loop.run_until_complete(
+        app._process(cancelled_future, queue, event_loop))
 
     assert actual == expected
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -108,3 +108,11 @@ def test_run_forever(good_mock_service, capsys):
     run('good_import:app')
     out, _ = capsys.readouterr()
     assert 'Run, Forrest, run!' in out
+
+
+def test_run_with_reloader(good_mock_service, capsys):
+    """Test that an app can be selected automatically."""
+    run('good_import', reloader=True)
+    out, _ = capsys.readouterr()
+    assert 'Running good_import.app with reloader' in out
+    assert 'Run, Forrest, run!' in out

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -47,7 +47,8 @@ def test_abort_preprocessor(event_loop, cancelled_future, queue):
         postprocess_called = True
         return result
 
-    event_loop.run_until_complete(app._process(cancelled_future, queue))
+    event_loop.run_until_complete(
+        app._process(cancelled_future, queue, event_loop))
 
     assert preprocess1_called
     assert not preprocess2_called
@@ -80,7 +81,8 @@ def test_abort_callback(event_loop, cancelled_future, queue):
         postprocess_called = True
         return result
 
-    event_loop.run_until_complete(app._process(cancelled_future, queue))
+    event_loop.run_until_complete(
+        app._process(cancelled_future, queue, event_loop))
 
     assert callback_called
     assert not postprocess_called
@@ -118,7 +120,8 @@ def test_abort_error(event_loop, cancelled_future, queue):
         nonlocal error2_called
         error2_called = True
 
-    event_loop.run_until_complete(app._process(cancelled_future, queue))
+    event_loop.run_until_complete(
+        app._process(cancelled_future, queue, event_loop))
 
     assert callback_called
     assert error1_called
@@ -157,7 +160,8 @@ def test_abort_postprocess(event_loop, cancelled_future, queue):
         postprocess2_called_count += 1
         return result
 
-    event_loop.run_until_complete(app._process(cancelled_future, queue))
+    event_loop.run_until_complete(
+        app._process(cancelled_future, queue, event_loop))
 
     assert postprocess1_called_count == 2
     assert postprocess2_called_count == 1


### PR DESCRIPTION
Currently, the reloader fails to start the application because the
thread spawned for it has no event loop. To fix that issue, a new event
loop is created and passed to `app.run_forever`. Additionally, this
loop is explicitly passed to all functions that take a `loop` argument
to ensure that the correct loop is always being used. Finally,
`run_forever` now calls `set_event_loop` to ensure that any other
async code running in the reloader thread (e.g. Henson extensions) that
may rely on the default event loop are not left without a loop to use.
