### PR TITLE
Remove outdated TODO

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -451,10 +451,6 @@ class Application:
         if results is None:
             return
 
-        # TODO: Evaluate this further. What are the pros and cons of
-        # operating over multiple results versus keeping it just one.
-        # As we look into asyncio, there may be benefits to yielding
-        # from callback rather than returning.
         for result in results:
             try:
                 yield from self._apply_callbacks(


### PR DESCRIPTION
Because asyncio uses generator coroutines, `yield` cannot be used in the
traditional sense. All values must be returned at once.