### PR TITLE
Prepare for upload to PyPI

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,12 @@
+include AUTHORS.rst
+include LICENSE
+include README.rst
+
+recursive-include docs Makefile *.py *.rst
+
+exclude .coveragerc
+exclude .travis.yml
+exclude tox.ini
+
+prune docs/_build
+prune tests

--- a/henson/__init__.py
+++ b/henson/__init__.py
@@ -1,6 +1,18 @@
 """Henson."""
 
+import os as _os
+import pkg_resources as _pkg_resources
+
 from .base import Application  # NOQA
 from .extensions import Extension  # NOQA
 
-__version__ = '0.5.0'
+try:
+    _dist = _pkg_resources.get_distribution(__package__)
+    if not __file__.startswith(_os.path.join(_dist.location, '__package__')):
+        # Manually raise the exception if there is a distribution but
+        # it's installed from elsewhere.
+        raise _pkg_resources.DistributionNotFound
+except _pkg_resources.DistributionNotFound:
+    __version__ = 'development'
+else:
+    __version__ = _dist.version

--- a/setup.py
+++ b/setup.py
@@ -1,19 +1,46 @@
 from setuptools import find_packages, setup
+from setuptools.command.test import test as TestCommand
+import sys
 
-from henson import __version__
+
+class PyTest(TestCommand):
+    def finalize_options(self):
+        super().finalize_options()
+        self.test_args = []
+        self.test_suite = True
+
+    def run_tests(self):
+        import pytest
+        sys.exit(pytest.main(self.test_args))
+
+
+def read(filename):
+    with open(filename) as f:
+        return f.read()
 
 setup(
     name='Henson',
-    version=__version__,
+    version='0.5.0',
+    author='Andy Dirnberger, Jon Banafato, and others',
+    author_email='henson@iheart.com',
+    url='https://henson.rtfd.org',
+    description='A framework for running a Python service driven by a consumer',
+    license='Apache License, Version 2.0',
+    long_description=read('README.rst'),
     packages=find_packages(exclude=['tests']),
+    zip_safe=False,
     install_requires=[
         # TODO: determine minimum versions for requirements
         'argh',
         'watchdog>=0.8.3',
     ],
     tests_require=[
-        'tox',
+        'pytest',
+        'pytest-asyncio',
     ],
+    cmdclass={
+        'test': PyTest,
+    },
     entry_points='''
         [console_scripts]
         henson=henson.cli:main


### PR DESCRIPTION
While there is still work to be done before we're ready to do a release,
these changes are needed to enable us to build a proper distribution. It
also includes enhancements such as making `python setup.py test` work.

The most noticeable change is moving the version back into `setup.py`.
The version was moved in fe9025c to make it easier to import from Henson
inside a REPL, but the new `try` block inside `henson/__init__.py` fixes
this while allowing `setup.py` to run without importing from Henson
directly.