### PR TITLE
Promote Abort

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -45,8 +45,7 @@ Quickstart
 
     import asyncio
 
-    from henson import Application
-    from henson.exceptions import Abort
+    from henson import Abort, Application
 
     class FileConsumer:
         """Read lines from a file."""

--- a/henson/__init__.py
+++ b/henson/__init__.py
@@ -4,6 +4,7 @@ import os as _os
 import pkg_resources as _pkg_resources
 
 from .base import Application  # NOQA
+from .exceptions import Abort  # NOQA
 from .extensions import Extension  # NOQA
 
 try:


### PR DESCRIPTION
`Abort` is important enough that it should be available as a top-level
import along with `Application` and `Extension`.

Closes #98