### PR TITLE
Don't require docstrings for magic methods

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,5 @@
 [bdist_wheel]
 universal = 1
+
+[flake8]
+ignore = D105


### PR DESCRIPTION
Magic methods are part of the data model and should be self explanatory.
Requiring docstrings for them is silly.