### PR TITLE
Fix version detection

### DIFF
--- a/henson/__init__.py
+++ b/henson/__init__.py
@@ -9,7 +9,7 @@ from .extensions import Extension  # NOQA
 
 try:
     _dist = _pkg_resources.get_distribution(__package__)
-    if not __file__.startswith(_os.path.join(_dist.location, '__package__')):
+    if not __file__.startswith(_os.path.join(_dist.location, __package__)):
         # Manually raise the exception if there is a distribution but
         # it's installed from elsewhere.
         raise _pkg_resources.DistributionNotFound


### PR DESCRIPTION
Henson should use the string assigned to ``__package__``, not the
literal string ``'__package__'``.