### PR TITLE
Don't build wheels for legacy versions of Python

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,2 @@
-[bdist_wheel]
-universal = 1
-
 [flake8]
 ignore = D105


### PR DESCRIPTION
Henson only supports Python 3.4+. There is no need to build a universal
wheel.