### PR TITLE
Fix find_packages

### DIFF
--- a/henson/contrib/__init__.py
+++ b/henson/contrib/__init__.py
@@ -1,0 +1,1 @@
+"""Henson's contrib packages."""


### PR DESCRIPTION
`find_packages` doesn't seem to recognize a package as a package when it
doesn't include a `__init__.py`. Such a file is being added to Henson's
contrib package so it will be included in the packages built by
setuptools.