### PR TITLE
Enable extending the command line interface

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,8 @@ Version 1.1.0
 
 Release TDB
 
+- Add ``henson.cli.register_commands`` to extend the command line interface
+
 Version 1.0.0
 -------------
 

--- a/docs/api.rst
+++ b/docs/api.rst
@@ -10,6 +10,12 @@ Application
 .. autoclass:: henson.base.Application
    :members:
 
+Command Line Interface
+======================
+
+.. automodule:: henson.cli
+   :members:
+
 Configuration
 =============
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -293,4 +293,7 @@ texinfo_documents = [
 
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'python': ('https://docs.python.org/3.5', None)}
+intersphinx_mapping = {
+    'argh': ('http://argh.readthedocs.org/en/latest/', None),
+    'python': ('https://docs.python.org/3.5', None),
+}

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -57,6 +57,71 @@ that are meant to be overridden:
   ``KeyError`` is raised. Extensions should set this when a value is required
   but has no default (e.g., a database password).
 
+Extending the Command Line
+==========================
+
+Henson offers an extensible command line interface. To register your own
+commands, use :func:`~henson.cli.register_commands`. Any function passed to it
+will have its usage created directly from its signature. In order to access the
+new commands, the ``henson`` command line utility must be given a reference to
+an :class:`~henson.base.Application`. This is done through the ``--app``
+argument:
+
+.. code::
+
+    $ henson --app APP_PATH
+
+.. note::
+
+    For details about the syntax to use when passing a reference to an
+    :class:`~henson.base.Application`, see :ref:`running-applications`.
+
+A positional argument in the Python function will result in a required
+positional argument in the command::
+
+    def trash(grouch):
+        pass
+
+.. code:: sh
+
+    $ henson --app APP_PATH NAMESPACE trash GROUCH
+
+A keyword argument in the Python function will result in a positional argument
+in the command with a default value to be used when the argument is omitted::
+
+    def trash(grouch='oscar'):
+        pass
+
+.. code:: sh
+
+    $ henson --app APP_PATH NAMESPACE trash [GROUCH]
+
+A keyword-only argument in the Python function will result in an optional
+argument in the command::
+
+    def trash(*, grouch='oscar'):
+        pass
+
+.. code:: sh
+
+    $ henson --app APP_PATH NAMESPACE trash [--grouch GROUCH]
+
+By default, all optional arguments will have a flag that matches the function
+argument's name. When no other optional arguments start with the same
+character, a single-character abbreviated flag can also be used.
+
+.. code:: sh
+
+    $ henson --app APP_PATH NAMESPACE trash [-g GROUCH]
+
+The ``trash`` function can then be registered with the CLI::
+
+    register_commands('sesame', [trash])
+
+.. code:: sh
+
+    $ henson --app APP_PATH sesame trash --help
+
 Available Extensions
 ====================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -31,6 +31,8 @@ Quickstart
 
 .. literalinclude:: file_consumer.py
 
+.. _running-applications:
+
 Running Applications
 ====================
 

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -1,17 +1,146 @@
 """Collection of Henson CLI tasks."""
 
+from argparse import Action
 import asyncio
+from collections import Counter
+from contextlib import suppress
+from functools import wraps
 from importlib import find_loader, import_module
+import inspect
 import os
 import sys
 from threading import Thread
 
 from argh import ArghParser, CommandError
+from argh.decorators import arg, expects_obj
 from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
 from . import __version__
 from .base import Application
+
+__all__ = ('register_commands',)
+
+
+def register_commands(namespace, functions, namespace_kwargs=None,
+                      func_kwargs=None):
+    """Register commands with the henson CLI.
+
+    The signature of each function provided through ``functions`` will
+    be mapped to its command's interface. Any positional arguments in
+    the function's signature will become required positional arguments
+    to the command. Keyword arguments in the signature will also become
+    positional arguments, although they will use the default value from
+    the signature when not specified on the command line. Keyword-only
+    arguments in the signature will become optional arguments on the
+    command line.
+
+    Args:
+        namespace (str): A name representing the group of commands. The
+            namespace is required to access the commands being added.
+        functions (List[callable]): A list of callables that are used to
+            create subcommands. More details can be found in the
+            documentation for :func:`~argh.assembling.add_commands`.
+
+    .. note::
+
+        This function is a wrapper around
+        :func:`~argh.assembling.add_commands`. Please refer to its
+        documentation for any arguments not explained here.
+
+    .. versionadded:: 1.1.0
+    """
+    commands = []
+
+    for function in functions:
+        # Inspect the function first. While everything it returns can be
+        # captured from the function object itself, the function will be
+        # decorated by the code below, altering its signature.  Using
+        # inspect here will capture a snapshot that can be used without
+        # alteration.
+        spec = inspect.getfullargspec(function)
+
+        # app is registered as an argument to the henson entry point
+        # directly. If the function accepts it as an argument, we need
+        # to make argh think the function accepts a namespace as its
+        # only argument, with all arguments being specified through the
+        # arg decorator. Using a namespace is also what allows us to
+        # treat keyword arguments as optional positional arguments, so
+        # all functions are wrapped by expects_obj and then
+        # _with_namespace.
+        accepts_app = 'app' in spec.args
+        function = _with_namespace(expects_obj(function), accepts_app)
+
+        with suppress(ValueError):
+            # Remove app from the list of arguments so that it doesn't
+            # get registered twice.
+            spec.args.remove('app')
+
+        # Associate values with keyword arguments.
+        if not spec.defaults:
+            # None isn't iterable.
+            defaults = {}
+        else:
+            defaults = dict(zip(
+                spec.args[-len(spec.defaults):],
+                spec.defaults))
+
+        # Keyword-only arguments are exposed to the command line as
+        # optional arguments. By default two flags are available for
+        # each: an abbreviated name (the first character) and a full
+        # name (with dashes instead of underscores). If two arguments
+        # share the same first letter, however, the abbreviated flags
+        # won't be used for them.
+        conflicts = Counter(a[0] for a in spec.kwonlyargs)
+        conflicts = tuple(k for k, v in conflicts.items() if v > 1)
+
+        # Iterate over the rest of the arguments. Positional and keyword
+        # arguments are combined by inspect, but keyword-only arguments
+        # are separate. They all need to be combined so that they can be
+        # iterated over in reverse order. The reverse is needed to
+        # retain the order of positional arguments as specified by the
+        # function's signature.
+        arguments = spec.args + spec.kwonlyargs
+        for argument in reversed(arguments):
+            kwargs = {}
+            if argument in spec.kwonlyargs:
+                # Treat keyword-only arguments as optional arguments.
+                kwargs['default'] = spec.kwonlydefaults[argument]
+                flags = (
+                    '-{0}'.format(argument[0]),
+                    '--{0}'.format(argument).replace('_', '-'),
+                )
+                if argument.startswith(conflicts):
+                    flags = flags[1:]
+            else:
+                # Treat all other arguments as positional arguments.
+                # Keyword arguments will be handled as positional
+                # arguments with default values.
+                with suppress(KeyError):
+                    # The argument will only be included in defaults
+                    # for keyword arguments.
+                    kwargs['default'] = defaults[argument]
+                    kwargs['nargs'] = '?'
+
+                # The argument's name is replaced by a list of flags for
+                # keyword-only arguments. Simulate that here so that the
+                # same call to arg can be used for all arguments.
+                flags = [argument]
+
+            with suppress(KeyError):
+                kwargs['help'] = spec.annotations[argument]
+
+            function = arg(*flags, **kwargs)(function)
+
+        # Add the function to the list of commands to add to the parser.
+        commands.append(function)
+
+    parser.add_commands(
+        namespace=namespace,
+        functions=commands,
+        namespace_kwargs=namespace_kwargs,
+        func_kwargs=func_kwargs,
+    )
 
 
 def run(application_path: 'the path to the application to run',
@@ -19,6 +148,74 @@ def run(application_path: 'the path to the application to run',
         workers: 'the number of asynchronous tasks to run' = 1,
         debug: 'enable debug mode' = False):
     """Import and run an application."""
+    import_path, app = _import_application(application_path)
+
+    if reloader:
+        # If the reloader is requested, create threads for running the
+        # application and watching the file system for changes
+        print('Running {!r} with reloader...'.format(app))
+
+        # Find the root of the application and watch for changes
+        watchdir = os.path.abspath(import_module(import_path).__file__)
+        for _ in import_path.split('.'):
+            watchdir = os.path.dirname(watchdir)
+
+        # Create observer and runner threads
+        observer = Observer()
+        loop = asyncio.new_event_loop()
+        runner = Thread(
+            target=app.run_forever,
+            kwargs={'num_workers': workers, 'loop': loop},
+        )
+
+        # This function is called by watchdog event handler when changes
+        # are detected by the observers
+        def restart_process(event):
+            """Restart the process in-place."""
+            os.execv(sys.executable, [sys.executable] + sys.argv[:])
+
+        # Create the handler and watch the files
+        handler = PatternMatchingEventHandler(
+            patterns=['*.py', '*.ini'],
+            ignore_directories=True,
+        )
+        handler.on_any_event = restart_process
+        observer.schedule(handler, watchdir, recursive=True)
+
+        # Start running everything
+        runner.start()
+        observer.start()
+
+    else:
+        # If the reloader is not needed, avoid the overhead
+        print('Running {!r} forever...'.format(app))
+        app.run_forever(num_workers=workers)
+
+
+class _ApplicationAction(Action):
+    """A custom action to import an application."""
+
+    def __call__(self, parser, namespace, values, option_string=None):
+        _, application = _import_application(values)
+        setattr(namespace, self.dest, application)
+
+
+def main():
+    """Dispatch the CLI command to the target function."""
+    return parser.dispatch()
+
+
+def _import_application(application_path):
+    """Return the imported application and the path to it.
+
+    Args:
+        application_path (str): The path to use to import the
+            application. It should be in the form of ``PATH[:APP]``.
+
+    Returns:
+        Tuple[str, henson.base.Application]: A two-tuple containing the
+            import path and the imported application.
+    """
     # Add the present working directory to the import path so that
     # services can be found without installing them to site-packages
     # or modifying PYTHONPATH
@@ -87,57 +284,27 @@ def run(application_path: 'the path to the application to run',
 
         app_name, app = app_candidates[0]
 
-    if reloader:
-        # If the reloader is requested, create threads for running the
-        # application and watching the file system for changes
-        print('Running {}.{} with reloader...'.format(
-            import_path,
-            app_name,
-        ))
-
-        # Find the root of the application and watch for changes
-        watchdir = os.path.abspath(module.__file__)
-        for _ in import_path.split('.'):
-            watchdir = os.path.dirname(watchdir)
-
-        # Create observer and runner threads
-        observer = Observer()
-        loop = asyncio.new_event_loop()
-        runner = Thread(
-            target=app.run_forever,
-            kwargs={'num_workers': workers, 'loop': loop},
-        )
-
-        # This function is called by watchdog event handler when changes
-        # are detected by the observers
-        def restart_process(event):
-            """Restart the process in-place."""
-            os.execv(sys.executable, [sys.executable] + sys.argv[:])
-
-        # Create the handler and watch the files
-        handler = PatternMatchingEventHandler(
-            patterns=['*.py', '*.ini'],
-            ignore_directories=True,
-        )
-        handler.on_any_event = restart_process
-        observer.schedule(handler, watchdir, recursive=True)
-
-        # Start running everything
-        runner.start()
-        observer.start()
-
-    else:
-        # If the reloader is not needed, avoid the overhead
-        print('Running {}.{} forever ...'.format(import_path, app_name))
-        app.run_forever(num_workers=workers)
+    return import_path, app
 
 
-def main():
-    """Dispatch the CLI command to the target function."""
-    return parser.dispatch()
+def _with_namespace(f, include_app):
+    """Call the function with the parsed arguments."""
+    @wraps(f)
+    def inner(parsed_args):
+        parsed_args = vars(parsed_args)
+        parsed_args.pop('_functions_stack', None)
+        if not include_app:
+            parsed_args.pop('app')
+        return f(**parsed_args)
+    return inner
 
 
 # Define a parser and add commands to it.
 parser = ArghParser()
+parser.add_argument(
+    '-a', '--app',
+    action=_ApplicationAction,
+    help='the path to the application to run',
+)
 parser.add_argument('--version', action='version', version=__version__)
 parser.add_commands([run])


### PR DESCRIPTION
Henson's command line interface is simple, offering just a `run`
command. This is a great starting point, but there is a world of
potential for extending the command line through extensions.
Unfortunately doing that requires knowing the implementation details of
the CLI and some trickery to register new commands.

A function, `register_commands`, is being added to make it easier for
extensions to register new commands. In addition to the new function, a
new argument, `--app` is being added to the CLI. Specifying an
application will result in it being imported, allowing any of its
extensions to register new commands. Commands can choose to receive the
application through an argument named `app`.

The usage for a new command is generated from the function's signature.
This is done much in the same way as argh does, but the `@arg` decorator
isn't needed for functions accepting `app`. `register_commands` will
handle this automatically.

The other deviation from argh's behavior is that namespaces are required
to extend Henson's CLI.