### PR TITLE
Support the command line debug flag

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -79,6 +79,10 @@ option::
 
     $ python -m henson run file_printer --debug
 
+.. note:: The ``--debug`` option is not recommended for production use.
+
+This will also enable the reloader.
+
 Logging
 =======
 

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -150,9 +150,10 @@ def run(application_path: 'the path to the application to run',
     """Import and run an application."""
     import_path, app = _import_application(application_path)
 
-    if reloader:
-        # If the reloader is requested, create threads for running the
-        # application and watching the file system for changes
+    if reloader or debug:
+        # If the reloader is requested (or debug is enabled), create
+        # threads for running the application and watching the file
+        # system for changes.
         print('Running {!r} with reloader...'.format(app))
 
         # Find the root of the application and watch for changes
@@ -165,7 +166,7 @@ def run(application_path: 'the path to the application to run',
         loop = asyncio.new_event_loop()
         runner = Thread(
             target=app.run_forever,
-            kwargs={'num_workers': workers, 'loop': loop},
+            kwargs={'num_workers': workers, 'loop': loop, 'debug': debug},
         )
 
         # This function is called by watchdog event handler when changes
@@ -189,7 +190,7 @@ def run(application_path: 'the path to the application to run',
     else:
         # If the reloader is not needed, avoid the overhead
         print('Running {!r} forever...'.format(app))
-        app.run_forever(num_workers=workers)
+        app.run_forever(num_workers=workers, debug=debug)
 
 
 class _ApplicationAction(Action):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -20,7 +20,7 @@ class MockApplication(Application):
         super().__init__('testing')
         self.settings = settings
 
-    def run_forever(self, num_workers=1, loop=None):
+    def run_forever(self, num_workers=1, loop=None, debug=False):
         """Run the instance."""
         print('Run, Forrest, run!')
 


### PR DESCRIPTION
Henson's debug mode was added in bea66d9. Unfortunately the command
line's debug flag was never passed along to `Application.run_forever`.
With this change it will now be passed. Enabling debug mode through the
command line will also enable the reloader.