### PR TITLE
Hotfix pin pytest-asyncio

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -5,7 +5,7 @@ envlist = docs,pep8,py34,py35
 deps =
     coverage
     pytest
-    pytest-asyncio
+    pytest-asyncio<0.4.0
 commands =
     python -m coverage run -m pytest --strict {posargs: tests}
     python -m coverage report -m --include="henson/*"


### PR DESCRIPTION
Due to changes that exist in `pytest-asyncio==0.4.1`, tests fail. This
hotfixes the issue until it can be addressed properly.