### PR TITLE
Add CLI usage to the documentation

### DIFF
--- a/docs-requirements.txt
+++ b/docs-requirements.txt
@@ -1,4 +1,5 @@
 doc8
 sphinx
 sphinx_rtd_theme
+sphinxcontrib-autoprogram
 sphinxcontrib-napoleon

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -7,6 +7,28 @@ Henson provides the following command line interface.
 .. autoprogram:: henson.cli:parser
    :prog: henson
 
+Further Details
+===============
+
+When developing locally, applications often need to be restarted as changes are
+made. To make this easier, Henson provides a ``--reloader`` option to the
+``run`` command. With this option enabled, Henson will watch an application's
+root directory and restart the application automatically when changes are
+detected::
+
+    $ python -m henson run file_printer --reloader
+
+.. note:: The ``--reloader`` option is not recommended for production use.
+
+It's also possible to enable Henson's :ref:`debug mode` through the ``--debug``
+option::
+
+    $ python -m henson run file_printer --debug
+
+.. note:: The ``--debug`` option is not recommended for production use.
+
+This will also enable the reloader.
+
 Extending the Command Line
 ==========================
 

--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -1,0 +1,14 @@
+======================
+Command Line Interface
+======================
+
+Henson provides the following command line interface.
+
+.. autoprogram:: henson.cli:parser
+   :prog: henson
+
+Extending the Command Line
+==========================
+
+For information about how to extension Henson's command line interface, see
+:ref:`extending-the-cli`.

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -36,6 +36,7 @@ extensions = [
     'sphinx.ext.intersphinx',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'sphinxcontrib.autoprogram',
     'sphinxcontrib.napoleon',
 ]
 

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -57,6 +57,8 @@ that are meant to be overridden:
   ``KeyError`` is raised. Extensions should set this when a value is required
   but has no default (e.g., a database password).
 
+.. _extending-the-cli:
+
 Extending the Command Line
 ==========================
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -116,6 +116,7 @@ Contents:
 
    interface
    callbacks
+   cli
    extensions
    contrib
    api

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -64,24 +64,8 @@ application. Any callable specified this way should require no arguments and
 return an instance of :class:`~henson.base.Application`. Autodiscovery of
 callables that return applications is not currently supported.
 
-When developing locally, applications often need to be restarted as changes are
-made. To make this easier, Henson provides a ``--reloader`` option to the
-``run`` command. With this option enabled, Henson will watch an application's
-root directory and restart the application automatically when changes are
-detected::
-
-    $ python -m henson run file_printer --reloader
-
-.. note:: The ``--reloader`` option is not recommended for production use.
-
-It's also possible to enable Henson's `debug mode`_ through the ``--debug``
-option::
-
-    $ python -m henson run file_printer --debug
-
-.. note:: The ``--debug`` option is not recommended for production use.
-
-This will also enable the reloader.
+More detailed information about Henson's command line interface can be found in
+:doc:`cli`.
 
 Logging
 =======


### PR DESCRIPTION
Through the use of `sphinxcontrib.autoprogram`, documenting Henson's
command line interface is really easy. It's also a nice thing to offer
people using Henson for the first time.