### PR TITLE
Update the Read the Docs domain

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -12,7 +12,7 @@ Henson |build status|
 
 A framework for running a Python service driven by a consumer.
 
-* `Documentation <https://henson.rtfd.org>`_
-* `Installation <https://henson.readthedocs.org/en/latest/#installation>`_
-* `Changelog <https://henson.readthedocs.org/en/latest/changes.html>`_
+* `Documentation <https://henson.readthedocs.io>`_
+* `Installation <https://henson.readthedocs.io/en/latest/#installation>`_
+* `Changelog <https://henson.readthedocs.io/en/latest/changes.html>`_
 * `Source <https://github.com/iheartradio/Henson>`_

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -295,6 +295,6 @@ texinfo_documents = [
 
 # Example configuration for intersphinx: refer to the Python standard library.
 intersphinx_mapping = {
-    'argh': ('http://argh.readthedocs.org/en/latest/', None),
+    'argh': ('https://argh.readthedocs.io/en/latest/', None),
     'python': ('https://docs.python.org/3.5', None),
 }

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -129,6 +129,6 @@ Available Extensions
 
 Several extensions are available for use:
 
-* `Henson-AMQP <https://henson-amqp.rtfd.org>`_
-* `Henson-Database <https://henson-database.rtfd.org>`_
-* `Henson-Logging <https://henson-logging.rtfd.org>`_
+* `Henson-AMQP <https://henson-amqp.readthedocs.io>`_
+* `Henson-Database <https://henson-database.readthedocs.io>`_
+* `Henson-Logging <https://henson-logging.readthedocs.io>`_

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,7 @@ setup(
     version='1.1.0',
     author='Andy Dirnberger, Jon Banafato, and others',
     author_email='henson@iheart.com',
-    url='https://henson.rtfd.org',
+    url='https://henson.readthedocs.io',
     description='A framework for running a Python service driven by a consumer',
     long_description=read('README.rst'),
     license='Apache License, Version 2.0',


### PR DESCRIPTION
Read the Docs has switched from using readthedocs.org to readthedocs.io
for project documentation. It includes the added benefit of having
better HTTPS support.