### PR TITLE
Log instead of print in CLI functions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Release TDB
 
 - Add ``henson.cli.register_commands`` to extend the command line interface
 - Messages are logged using ``logging.DEBUG`` instead of ``logging.INFO``
+- Calls to ``print`` in ``henson.cli.run`` are updated to ``app.logger.debug``
 
 Version 1.0.0
 -------------

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -154,7 +154,7 @@ def run(application_path: 'the path to the application to run',
         # If the reloader is requested (or debug is enabled), create
         # threads for running the application and watching the file
         # system for changes.
-        print('Running {!r} with reloader...'.format(app))
+        app.logger.debug('Running {!r} with reloader...'.format(app))
 
         # Find the root of the application and watch for changes
         watchdir = os.path.abspath(import_module(import_path).__file__)
@@ -189,7 +189,7 @@ def run(application_path: 'the path to the application to run',
 
     else:
         # If the reloader is not needed, avoid the overhead
-        print('Running {!r} forever...'.format(app))
+        app.logger.debug('Running {!r} forever...'.format(app))
         app.run_forever(num_workers=workers, debug=debug)
 
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -203,17 +203,17 @@ def test_register_commands_positional(monkeypatch):
     assert args.b == '2'
 
 
-def test_run_forever(good_mock_service, capsys):
+def test_run_forever(good_mock_service, caplog, capsys):
     """Test that run_forever is called on the imported app."""
     cli.run('good_import:app')
     out, _ = capsys.readouterr()
-    assert 'Running <Application: testing> forever' in out
+    assert 'Running <Application: testing> forever' in caplog.text()
     assert 'Run, Forrest, run!' in out
 
 
-def test_run_with_reloader(good_mock_service, capsys):
+def test_run_with_reloader(good_mock_service, caplog, capsys):
     """Test that an app is run with the reloader."""
     cli.run('good_import:app', reloader=True)
     out, _ = capsys.readouterr()
-    assert 'Running <Application: testing> with reloader' in out
+    assert 'Running <Application: testing> with reloader' in caplog.text()
     assert 'Run, Forrest, run!' in out

--- a/tox.ini
+++ b/tox.ini
@@ -6,6 +6,7 @@ deps =
     coverage
     pytest
     pytest-asyncio<0.4.0
+    pytest-capturelog
 commands =
     python -m coverage run -m pytest --strict {posargs: tests}
     python -m coverage report -m --include="henson/*"


### PR DESCRIPTION
Logging is friendlier and more configurable than printing.