### PR TITLE
Remove references to objects when no longer needed

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -6,6 +6,9 @@ Release TDB
 - Add ``henson.cli.register_commands`` to extend the command line interface
 - Messages are logged using ``logging.DEBUG`` instead of ``logging.INFO``
 - Calls to ``print`` in ``henson.cli.run`` are updated to ``app.logger.debug``
+- References to objects used by ``henson.Application`` are removed once they
+  are no longer needed to allow the memory to be freed up before the next
+  message is received.
 
 Version 1.0.0
 -------------


### PR DESCRIPTION
Henson applications process incoming messages inside a while loop that
checks for new items in the internal queue at the beginning of each
iteration. Variables inside the while loop don't get reassigned until an
iteration finds something in the queue. This means that applications
that spend a significant amount of time idling will hold onto memory
unnecessarily. By removing the references to the objects that stick
around, the memory can be freed for use by other things.