### PR TITLE
Add support for uvloop

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,7 @@ Release TDB
 - References to objects used by ``henson.Application`` are removed once they
   are no longer needed to allow the memory to be freed up before the next
   message is received.
+- uvloop_ will be used for the event loop if it's installed.
 
 Version 1.0.0
 -------------
@@ -16,3 +17,5 @@ Version 1.0.0
 Released 2016-03-01
 
 - Initial release
+
+.. _uvloop: https://uvloop.readthedocs.io

--- a/henson/base.py
+++ b/henson/base.py
@@ -167,7 +167,7 @@ class Application:
             raise TypeError("The Application's callback must be a coroutine.")
 
         # Use the specified event loop, otherwise use the default one.
-        loop = loop or asyncio.get_event_loop()
+        loop = loop or _new_event_loop()
         asyncio.set_event_loop(loop)
 
         # Start the application.
@@ -467,3 +467,22 @@ class Application:
             self._callbacks['teardown']]
         future = asyncio.gather(*tasks, loop=loop)
         loop.run_until_complete(future)
+
+
+def _new_event_loop():
+    """Return a new event loop.
+
+    If `uvloop <https://uvloop.readthedocs.io>`_ is installed, its event
+    loop will be used. Otherwise, the default event loop provided by
+    asyncio will be used. The latter behavior can be overridden by
+    setting the event loop policy.
+
+    Returns:
+        asyncio.AbstractEventLoopPolicy: The new event loop.
+    """
+    try:
+        import uvloop
+    except ImportError:
+        return asyncio.new_event_loop()
+    else:
+        return uvloop.new_event_loop()

--- a/tests/test_misc.py
+++ b/tests/test_misc.py
@@ -1,0 +1,39 @@
+"""Miscellaneous tests that don't have a better home."""
+
+import asyncio
+import asyncio.base_events
+import sys
+
+from henson.base import _new_event_loop
+
+
+def test_new_event_loop(monkeypatch, request):
+    """Test that _new_event_loop returns the default event loop."""
+    policy = asyncio.get_event_loop_policy()
+
+    def restore_event_loop_policy():
+        asyncio.set_event_loop_policy(policy)
+    request.addfinalizer(restore_event_loop_policy)
+
+    asyncio.set_event_loop_policy(None)
+
+    event_loop = _new_event_loop()
+    assert isinstance(event_loop, asyncio.base_events.BaseEventLoop)
+
+
+def test_new_event_loop_uvloop(monkeypatch, request):
+    """Test that uvloop's event policy is used when its installed."""
+    expected = 'event loop'
+
+    # Inject the stub uvloop into the imported modules so that we don't
+    # actually need to install it to run this test.
+    class uvloop:
+        @staticmethod
+        def new_event_loop():
+            return expected
+
+    monkeypatch.setitem(sys.modules, 'uvloop', uvloop)
+
+    actual = _new_event_loop()
+
+    assert actual == expected


### PR DESCRIPTION
uvloop is an alternate event loop for use with asyncio. While it's easy
to provide a specific event loop for a Henson application to use when
calling `run_forever` directly, there's no easy way to do so when using
the `henson run` CLI. Because uvloop is a drop-in replacement, it's easy
to add support for it directly into Henson by checking for it at run
time.

I had originally implemented this by setting the event loop policy at
compile time. While that approach feels a tad bit cleaner (easier to
remove if we need to stop support uvloop), this approach is much easier
to test.