### PR TITLE
Add verbosity controls to the run command

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,7 +5,7 @@ Release TDB
 
 - Add ``henson.cli.register_commands`` to extend the command line interface
 - Messages are logged using ``logging.DEBUG`` instead of ``logging.INFO``
-- Calls to ``print`` in ``henson.cli.run`` are updated to ``app.logger.debug``
+- Calls to ``print`` in ``henson.cli.run`` are updated to ``app.logger.info``
 - References to objects used by ``henson.Application`` are removed once they
   are no longer needed to allow the memory to be freed up before the next
   message is received.

--- a/henson/base.py
+++ b/henson/base.py
@@ -188,9 +188,11 @@ class Application:
             self.settings['DEBUG'] = True
         if self.settings['DEBUG']:
             # If the application is running in debug mode, enable it for
-            # the loop and set the logger to DEBUG.
+            # the loop and set the logger to DEBUG. If, however, the
+            # log level was set to something lower than DEBUG, don't
+            # change it.
             loop.set_debug(True)
-            self.logger.setLevel(logging.DEBUG)
+            self.logger.setLevel(min(self.logger.level, logging.DEBUG))
 
         self.logger.debug('application.started')
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -11,6 +11,13 @@ from henson import cli, Application
 
 
 @pytest.fixture
+def cli_kwargs():
+    """Return keyword arguments for CLI actions."""
+    # Use 1 for verbose to enable INFO logging.
+    return {'quiet': False, 'verbose': 1}
+
+
+@pytest.fixture
 def modules_tmpdir(tmpdir, monkeypatch):
     """Add a temporary directory for modules to sys.path."""
     tmp = tmpdir.mkdir('tmp_modules')
@@ -203,17 +210,17 @@ def test_register_commands_positional(monkeypatch):
     assert args.b == '2'
 
 
-def test_run_forever(good_mock_service, caplog, capsys):
+def test_run_forever(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that run_forever is called on the imported app."""
-    cli.run('good_import:app')
+    cli.run('good_import:app', **cli_kwargs)
     out, _ = capsys.readouterr()
     assert 'Running <Application: testing> forever' in caplog.text()
     assert 'Run, Forrest, run!' in out
 
 
-def test_run_with_reloader(good_mock_service, caplog, capsys):
+def test_run_with_reloader(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that an app is run with the reloader."""
-    cli.run('good_import:app', reloader=True)
+    cli.run('good_import:app', reloader=True, **cli_kwargs)
     out, _ = capsys.readouterr()
     assert 'Running <Application: testing> with reloader' in caplog.text()
     assert 'Run, Forrest, run!' in out


### PR DESCRIPTION
A mutually exclusive set of arguments is being added to the `henson run`
command: `--quiet` and `--verbose`. Providing one of the arguments will
alter the level of logging used by Henson's logger. While `run` only
supports one level of quiet, both arguments are counts. The more times
`--verbose` is specified, the lower the log level threshold will be.

As part of this, `run`'s logging calls are being raised from `DEBUG` to
`INFO` so that they will be logged upon the use of a single `--verbose`.

Closes #131 