### PR TITLE
Add extension registry

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -10,6 +10,7 @@ Release TDB
   are no longer needed to allow the memory to be freed up before the next
   message is received.
 - uvloop_ will be used for the event loop if it's installed.
+- Automatically register extensions to a registry on the application
 
 Version 1.0.0
 -------------

--- a/henson/base.py
+++ b/henson/base.py
@@ -55,6 +55,8 @@ class Application:
             'teardown': [],
         }
 
+        self.extensions = {}
+
         self.consumer = consumer
 
         self.logger = logging.getLogger(self.name)

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -78,6 +78,7 @@ class Extension:
             )
 
         self._app = app
+        self._app.extensions[self.__class__.__name__.lower()] = self
 
     @property
     def app(self):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,6 +19,7 @@ class MockApplication(Application):
         """Initialize the instance."""
         super().__init__('testing')
         self.settings = settings
+        self.extensions = {}
 
     def run_forever(self, num_workers=1, loop=None, debug=False):
         """Run the instance."""

--- a/tests/test_extensions.py
+++ b/tests/test_extensions.py
@@ -24,6 +24,15 @@ def test_app_access_with_no_app_raises_runtimeerror():
         Extension().app
 
 
+def test_extension_registry(test_app):
+    """Test that extensions are automatically registered with the app."""
+    class CustomExtension(Extension):
+        pass
+
+    extension = CustomExtension(test_app)
+    assert test_app.extensions['customextension'] == extension
+
+
 def test_extension_without_default_settings(test_app):
     """Test that an Extension without DEFAULT_SETTINGS doesn't affect app."""
     class CustomExtension(Extension):


### PR DESCRIPTION
Some extensions (e.g. Henson-Database) require an `app.extensions`
registry. Instead of relying on them creating this on their own,
automatically create the registry on the application and register
extensions using their names.