### PR TITLE
Add a Sphinx plugin to autogenerate CLI docs

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -11,6 +11,8 @@ Release TDB
   message is received.
 - uvloop_ will be used for the event loop if it's installed.
 - Automatically register extensions to a registry on the application
+- Add ``hensoncli`` Sphinx directive to document extensions to the command line
+  interface
 
 Version 1.0.0
 -------------

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -37,6 +37,7 @@ extensions = [
     'sphinx.ext.napoleon',
     'sphinx.ext.todo',
     'sphinx.ext.viewcode',
+    'henson.contrib.sphinx',
     'sphinxcontrib.autoprogram',
 ]
 

--- a/docs/contrib/sphinx.rst
+++ b/docs/contrib/sphinx.rst
@@ -1,0 +1,12 @@
+======
+Sphinx
+======
+
+The Sphinx contrib plugin adds a directive that can be used to document
+extensions to the Henson command line interface.
+
+.. autoclass:: henson.contrib.sphinx.HensonCLIDirective
+
+For full details of the options support by the ``hensoncli`` directive, please
+refer to the
+`sphinxcontrib-autoprogram documentation <https://pythonhosted.org/sphinxcontrib-autoprogram/#additional-options-for-autoprogram>`_.

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -64,10 +64,16 @@ Extending the Command Line
 
 Henson offers an extensible command line interface. To register your own
 commands, use :func:`~henson.cli.register_commands`. Any function passed to it
-will have its usage created directly from its signature. In order to access the
-new commands, the ``henson`` command line utility must be given a reference to
-an :class:`~henson.base.Application`. This is done through the ``--app``
-argument:
+will have its usage created directly from its signature. During the course of
+initializing the application for use with the extension (i.e.,
+:meth:`~henson.extensions.Extension.init_app`), Henson will check for a method
+on the extension's instance named ``register_cli`` and call it. If you place
+any calls to :func:`~henson.cli.register_commands` inside it, the command line
+interface will be extended automatically.
+
+In order to access the new commands, the ``henson`` command line utility must
+be given a reference to an :class:`~henson.base.Application`. This is done
+through the ``--app`` argument:
 
 .. code::
 

--- a/henson/contrib/sphinx/__init__.py
+++ b/henson/contrib/sphinx/__init__.py
@@ -1,0 +1,49 @@
+"""Sphinx contrib plugin for documenting Henson CLI extensions."""
+
+from sphinxcontrib.autoprogram import AutoprogramDirective
+
+
+def _import_extension(import_path):
+    module_name, extension_name = import_path.split(':', 1)
+    module = __import__(module_name, None, None, [extension_name])
+    return getattr(module, extension_name)
+
+
+class HensonCLIDirective(AutoprogramDirective):
+    """A Sphinx directive that can be used to document a CLI extension.
+
+    This class wraps around
+    `autoprogram <https://pythonhosted.org/sphinxcontrib-autoprogram/>`_
+    to generate Sphinx documentation for extensions that extend the
+    Henson CLI.
+
+    .. code::
+
+        .. hensoncli:: henson_database:Database
+           :start_command: db
+
+    .. versionadded:: 1.1.0
+    """
+
+    def prepare_autoprogram(self):
+        """Prepare the instance to be run through autoprogram."""
+        # Tell autoprogram how to find the argument parser.
+        self.arguments = 'henson.cli:parser',
+
+    def register_cli(self):
+        """Register the CLI."""
+        import_path, = self.arguments
+        extension = _import_extension(import_path)
+        extension().register_cli()
+
+    def run(self):
+        """Register the CLI and run autoprogram."""
+        self.register_cli()
+        self.prepare_autoprogram()
+
+        return super().run()
+
+
+def setup(app):
+    """Register the extension."""
+    app.add_directive('hensoncli', HensonCLIDirective)

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -77,6 +77,9 @@ class Extension:
                 )
             )
 
+        if hasattr(self, 'register_cli'):
+            self.register_cli()
+
         self._app = app
         self._app.extensions[self.__class__.__name__.lower()] = self
 

--- a/setup.py
+++ b/setup.py
@@ -34,6 +34,11 @@ setup(
         'argh',
         'watchdog>=0.8.3',
     ],
+    extras_require={
+        'sphinx': [
+            'sphinxcontrib-autoprogram>=0.1.3',
+        ],
+    },
     tests_require=[
         'pytest',
         'pytest-asyncio',

--- a/tests/contrib/test_sphinx.py
+++ b/tests/contrib/test_sphinx.py
@@ -1,0 +1,76 @@
+"""Tests for henson.contrib.sphinx."""
+
+from docutils.statemachine import StringList
+import pytest
+
+from henson import Extension
+from henson.contrib import sphinx
+
+
+@pytest.fixture
+def modules_tmpdir(tmpdir, monkeypatch):
+    """Add a temporary directory for modules to sys.path."""
+    tmp = tmpdir.mkdir('tmp_modules')
+    monkeypatch.syspath_prepend(str(tmp))
+    return tmp
+
+
+@pytest.fixture
+def test_module(modules_tmpdir, test_app):
+    """Create a module for a fake extension."""
+    fake_extension = modules_tmpdir.join('fake_extension.py')
+    fake_extension.write('\n'.join((
+        'from henson import Extension',
+        'class FakeExtension(Extension):',
+        '    def register_cli(self): pass',
+    )))
+
+
+@pytest.fixture
+def test_directive(test_module):
+    """Return an instance of HensonCLIDirective."""
+    return sphinx.HensonCLIDirective(
+        name='hensoncli',
+        arguments=['fake_extension:FakeExtension'],
+        options={},
+        content=StringList([], items=[]),
+        lineno=1,
+        content_offset=0,
+        block_text='.. hensoncli:: fake_extension:FakeExtension\n',
+        state=None,
+        state_machine=None,
+    )
+
+
+def test_hensoncliextensiondirective_sets_parser(test_directive):
+    """Test that HensonCLIDirective.prepare_autoprogram sets the parser."""
+    test_directive.prepare_autoprogram()
+    assert test_directive.arguments == ('henson.cli:parser',)
+
+
+def test_hensoncliextentiondirective_register_cli(test_directive):
+    """Test that HensonCLIDirective.register_cli doesn't fail."""
+    # This will only test that it runs without raising an exception.
+    test_directive.register_cli()
+
+
+def test_import_extension(test_module):
+    """Test that _import_extension returns the extension."""
+    import_path = 'fake_extension:FakeExtension'
+    extension = sphinx._import_extension(import_path)
+    assert issubclass(extension, Extension)
+
+
+def test_setup():
+    """Test that setup registers the directive."""
+    class SphinxApplication:
+        def add_directive(self, directive, cls):
+            self.directive = directive
+            self.cls = cls
+
+    app = SphinxApplication()
+
+    sphinx.setup(app)
+
+    assert app.directive == 'hensoncli'
+    assert app.cls is sphinx.HensonCLIDirective

--- a/tox.ini
+++ b/tox.ini
@@ -7,6 +7,7 @@ deps =
     pytest
     pytest-asyncio<0.4.0
     pytest-capturelog
+    sphinxcontrib-autoprogram
 commands =
     python -m coverage run -m pytest --strict {posargs: tests}
     python -m coverage report -m --include="henson/*"


### PR DESCRIPTION
There is a Sphinx extension named autoprogram that will autogenerate
Sphinx documentation for a CLI. This works great for Henson itself.
Unfortunately it falls short when documenting Henson extensions because
the extension needs to register its subcommands in order for them to be
associated with the CLI.

A new contrib plugin is being added (`henson.contrib.sphinx`). It wraps
around autoprogram and handles importing the extension automatically.