### PR TITLE
Add support for verbosity to CLI extensions

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -13,6 +13,8 @@ Release TDB
 - Automatically register extensions to a registry on the application
 - Add ``hensoncli`` Sphinx directive to document extensions to the command line
   interface
+- ``henson.cli.run`` and any command line extensions that request it support
+  ``quiet`` and ``verbose`` flags to set verbosity
 
 Version 1.0.0
 -------------

--- a/docs/extensions.rst
+++ b/docs/extensions.rst
@@ -130,6 +130,24 @@ The ``trash`` function can then be registered with the CLI::
 
     $ henson --app APP_PATH sesame trash --help
 
+Additionally, if a command includes a ``quiet`` or ``verbose`` argument, it
+will automatically receive the count of the number of times it was specified
+(e.g., ``-v`` will have the value ``1``, ``-vv`` will have the value ``2``).
+When both arguments are included, they will be added as a mutually exclusive
+group.
+
+.. note::
+
+    Due to how :meth:`argparse <python:argparse.ArgumentParser.add_argument>`
+    handles argument counts, ``quiet`` and ``verbose`` will be set to ``None``
+    rather than ``0`` when the flag isn't specified when the command is
+    invoked.
+
+.. code:: sh
+
+    $ henson --app APP_PATH sesame trash -vvvv
+    $ henson --app APP_PATH sesame trash --quiet
+
 Available Extensions
 ====================
 

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -210,6 +210,78 @@ def test_register_commands_positional(monkeypatch):
     assert args.b == '2'
 
 
+@pytest.mark.parametrize('arguments, expected', (
+    (['-q'], 1),
+    (['-qq'], 2),
+    (['--quiet'], 1),
+    (['--quiet', '--quiet'], 2),
+))
+def test_register_commands_quiet(monkeypatch, arguments, expected):
+    """Test that register_commands handles quiet."""
+    monkeypatch.setattr(cli, 'parser', ArghParser('testing'))
+
+    def verbosity(quiet):
+        pass
+
+    cli.register_commands('testing', [verbosity])
+
+    args = cli.parser.parse_args(['testing', 'verbosity'] + arguments)
+    assert args.quiet == expected
+
+
+@pytest.mark.parametrize('arguments, quiet, verbose', (
+    ('-q', 1, None),
+    ('-qq', 2, None),
+    ('-v', None, 1),
+    ('-vv', None, 2),
+))
+def test_register_commands_quiet_and_verbose(monkeypatch, arguments, quiet,
+                                             verbose):
+    """Test that register_commands handles quiet and verbose."""
+    monkeypatch.setattr(cli, 'parser', ArghParser('testing'))
+
+    def verbosity(quiet, verbose):
+        pass
+
+    cli.register_commands('testing', [verbosity])
+
+    args = cli.parser.parse_args(['testing', 'verbosity', arguments])
+    assert args.quiet == quiet
+    assert args.verbose == verbose
+
+
+def test_register_commands_quiet_and_verbose_together_systemexit(monkeypatch):
+    """Test that register_commands with quiet and verbose raises SystemExit."""
+    monkeypatch.setattr(cli, 'parser', ArghParser('testing'))
+
+    def verbosity(quiet, verbose):
+        pass
+
+    cli.register_commands('testing', [verbosity])
+
+    with pytest.raises(SystemExit):
+        cli.parser.parse_args(['testing', 'verbosity', '-q', '-v'])
+
+
+@pytest.mark.parametrize('arguments, expected', (
+    (['-v'], 1),
+    (['-vv'], 2),
+    (['--verbose'], 1),
+    (['--verbose', '--verbose'], 2),
+))
+def test_register_commands_verbose(monkeypatch, arguments, expected):
+    """Test that register_commands handles quiet."""
+    monkeypatch.setattr(cli, 'parser', ArghParser('testing'))
+
+    def verbosity(verbose):
+        pass
+
+    cli.register_commands('testing', [verbosity])
+
+    args = cli.parser.parse_args(['testing', 'verbosity'] + arguments)
+    assert args.verbose == expected
+
+
 def test_run_forever(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that run_forever is called on the imported app."""
     cli.run('good_import:app', **cli_kwargs)


### PR DESCRIPTION
With this change, any function used to extend the Henson command line
will be given the same level of support for `quiet` and `verbose` as
Henson's `run` command.