### PR TITLE
Add Python 3.6 to the list of supported versions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,21 +1,20 @@
-# Use Python
 language: python
 
-# Run the test runner using the same version of Python we use.
-python: 3.6
+matrix:
+  include:
+    - python: 3.4
+      env: TOX_ENV=py34
+    - python: 3.5
+      env: TOX_ENV=py35
+    - python: 3.6
+      env: TOX_ENV=py36
+    - python: 3.6
+      env: TOX_ENV=docs
+    - python: 3.6
+      env: TOX_ENV=pep8
 
-# Install the test runner.
 install: pip install tox
-
-# Run each environment separately so we get errors back from all of them.
-env:
-  - TOX_ENV=py36
-  - TOX_ENV=py35
-  - TOX_ENV=py34
-  - TOX_ENV=pep8
-  - TOX_ENV=docs
-script:
-  - tox -e $TOX_ENV
+script: tox -e $TOX_ENV
 
 # Control the branches that get built.
 branches:

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,13 +2,14 @@
 language: python
 
 # Run the test runner using the same version of Python we use.
-python: 3.5
+python: 3.6
 
 # Install the test runner.
 install: pip install tox
 
 # Run each environment separately so we get errors back from all of them.
 env:
+  - TOX_ENV=py36
   - TOX_ENV=py35
   - TOX_ENV=py34
   - TOX_ENV=pep8

--- a/setup.py
+++ b/setup.py
@@ -59,6 +59,7 @@ setup(
         'Programming Language :: Python',
         'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [tox]
-envlist = docs,pep8,py34,py35
+envlist = docs,pep8,py34,py35,py36
 
 [testenv]
 deps =
@@ -13,14 +13,14 @@ commands =
     python -m coverage report -m --include="henson/*"
 
 [testenv:docs]
-basepython = python3.5
+basepython = python3.6
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.5
+basepython = python3.6
 deps =
     flake8-docstrings
     pep8-naming


### PR DESCRIPTION
In order to use both Python 3.5 and 3.6 on Travis CI, both need to be
included in the list of Python versions. This would result in the entire
build matrix being run using both versions. 3.5 jobs would fail on the
3.6 image and 3.6 jobs would fail on the 3.5 image.

While more verbose than what we had before, this build matrix allows us
to run each job with the correct version of Python.