### PR TITLE
Halt processing after an exception

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -3,6 +3,9 @@ Version 1.2.0
 
 Release TBD
 
+- Unhandled exceptions raised while processing a message will stop the
+  application
+
 Version 1.1.0
 -------------
 

--- a/henson/base.py
+++ b/henson/base.py
@@ -161,6 +161,12 @@ class Application:
         Raises:
             TypeError: If the consumer is None or the callback isn't a
                 coroutine.
+
+        .. versionchanged:: 1.2
+
+            Unhandled exceptions resulting from processing a message
+            while the consumer is still active will stop cause the
+            application to shut down gracefully.
         """
         if self.consumer is None:
             raise TypeError("The Application's consumer cannot be None.")
@@ -219,18 +225,20 @@ class Application:
         future = asyncio.gather(*tasks, loop=loop)
 
         try:
-            # Run the loop until the consumer says to stop.
-            loop.run_until_complete(consumer)
+            # Run the loop until the consumer says to stop or message
+            # processing fails.
+            loop.run_until_complete(asyncio.gather(consumer, future))
         except BaseException as e:
             self.logger.error(e)
-
-            # If something went wrong, cancel the consumer. This will
-            # alert the processors to stop once the queue is empty.
-            consumer.cancel()
         finally:
-            # Run the loop until the future completes. This will allow
-            # the tasks to finish processing all of the messages in the
-            # queue and then exit cleanly.
+            # If something went wrong while processing the message,
+            # cancel the consumer. This will alert the processors to
+            # stop once the queue is empty.
+            consumer.cancel()
+
+            # Run the loop until message processing completes. This will
+            # allow the tasks to finish processing all of the messages
+            # in the queue and then exit cleanly.
             loop.run_until_complete(future)
 
             # Check for any exceptions that may have been raised by the


### PR DESCRIPTION
Currently the only way to stop the application (without the use of
`SIGTERM` or `SIGKILL`) is for the consumer to shut down (either
naturally or through an exception). When a `_process` future fails,
`future` will be stopped. Because the event loop is only monitoring the
`consume` future, however, the application will keep running with the
consumer blocked by a full queue.

This normally isn't an issue as most of `_process` happens inside a
try/except block. There are three instances, however, where exceptions
will not be handled:

    - result postprocessing: This happens inside the try's else block.
    - error callbacks: This happens inside the try's except block.
      `Abort` will be caught, but nothing else.
    - message acknowledgement: This happens inside the try's finally
      block.

By changing the call to `run_until_complete` to monitor a future that
includes both the consumer and processing futures, an exception raised
by either will end the application.