### PR TITLE
Reduce the number of futures used for consuming

### DIFF
--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -36,13 +36,13 @@ def test_apply_callbacks(original, expected):
     assert callback2_called
 
 
-def test_consume(event_loop, test_consumer, cancelled_future):
+def test_consume(event_loop, test_consumer):
     """Test Application._consume."""
     queue = asyncio.Queue(maxsize=1)
 
     app = Application('testing', consumer=test_consumer)
 
-    asyncio.async(app._consume(queue, cancelled_future))
+    asyncio.async(app._consume(queue))
 
     event_loop.stop()  # Run the event loop once.
     event_loop.run_forever()


### PR DESCRIPTION
`run_forever` creates a future to keep track of whether or not the
consumer is still running. It then creates a separate task from the
future. If the application is stopped by some means other than the
first future completing on its own, the task often raises a
`RuntimeError` will trying to do something after the event loop has been
closed.

There is no need to keep track of both futures. A task can be made from
the `_consume` coroutine. When `_consume` exits, the task will be marked
done, when `consumer.cancel` is called the task will be stopped cleanly.