### PR TITLE
Set the event loop when running with reloader

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -5,6 +5,7 @@ Release TBD
 
 - Unhandled exceptions raised while processing a message will stop the
   application
+- Set the event loop when running with the reloader
 
 Version 1.1.0
 -------------

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -1,7 +1,6 @@
 """Collection of Henson CLI tasks."""
 
 from argparse import Action
-import asyncio
 from collections import Counter
 from copy import deepcopy
 from contextlib import suppress
@@ -19,7 +18,7 @@ from watchdog.events import PatternMatchingEventHandler
 from watchdog.observers import Observer
 
 from . import __version__
-from .base import Application
+from .base import Application, _new_event_loop
 
 __all__ = ('register_commands',)
 
@@ -213,7 +212,7 @@ def run(application_path: 'the path to the application to run',
 
         # Create observer and runner threads
         observer = Observer()
-        loop = asyncio.new_event_loop()
+        loop = _new_event_loop()
         runner = Thread(
             target=app.run_forever,
             kwargs={'num_workers': workers, 'loop': loop, 'debug': debug},


### PR DESCRIPTION
Normally Henson applications can take care of setting their own event
loops. When running with the reloader, however, a loop is needed to
ensure that the same event loop is always used each time the application
is started. The `_new_event_loop` function added in 58cac31 can be used
for this.