### PR TITLE
Provide a default start command for CLI extensions

### DIFF
--- a/henson/contrib/sphinx/__init__.py
+++ b/henson/contrib/sphinx/__init__.py
@@ -23,12 +23,22 @@ class HensonCLIDirective(AutoprogramDirective):
            :start_command: db
 
     .. versionadded:: 1.1.0
+
+    .. versionchanged:: 1.2.0
+
+        The ``prog`` option will default to the proper way to invoke
+        command line extensions.
     """
 
     def prepare_autoprogram(self):
         """Prepare the instance to be run through autoprogram."""
         # Tell autoprogram how to find the argument parser.
         self.arguments = 'henson.cli:parser',
+
+        # Most Henson CLI extensions will be invoked the same way. The
+        # extension authors shouldn't have to include that in their
+        # Sphinx documentation.
+        self.options.setdefault('prog', 'henson --app APP_PATH')
 
     def register_cli(self):
         """Register the CLI."""

--- a/tests/contrib/test_sphinx.py
+++ b/tests/contrib/test_sphinx.py
@@ -42,13 +42,26 @@ def test_directive(test_module):
     )
 
 
-def test_hensoncliextensiondirective_sets_parser(test_directive):
+def test_hensonclidirective_doesnt_change_prog(test_directive):
+    """Test that HensonCLIDirective.prepare_autoprogram doesn't change prog."""
+    test_directive.options['prog'] = 'testing'
+    test_directive.prepare_autoprogram()
+    assert test_directive.options['prog'] == 'testing'
+
+
+def test_hensonclidirective_sets_parser(test_directive):
     """Test that HensonCLIDirective.prepare_autoprogram sets the parser."""
     test_directive.prepare_autoprogram()
     assert test_directive.arguments == ('henson.cli:parser',)
 
 
-def test_hensoncliextentiondirective_register_cli(test_directive):
+def test_hensonclidirective_sets_prog(test_directive):
+    """Test that HensonCLIDirective.prepare_autoprogram sets prog."""
+    test_directive.prepare_autoprogram()
+    assert test_directive.options['prog'] == 'henson --app APP_PATH'
+
+
+def test_hensonclidirective_register_cli(test_directive):
     """Test that HensonCLIDirective.register_cli doesn't fail."""
     # This will only test that it runs without raising an exception.
     test_directive.register_cli()


### PR DESCRIPTION
When building the documentation for Henson plugins, sphinx-autoprogram
picks up `sphinx-build` as the program. This requires setting the `prog`
option whenever a plugin uses the Henson Sphinx extension to document
its CLI. This change will provide a default value of
`henson --app APP_PATH` so that plugin authors can omit it.