### PR TITLE
Make Tox Pass

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -83,6 +83,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         self._register_callback(callback, 'error')
         return callback
@@ -102,6 +103,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         self._register_callback(callback, 'message_acknowledgement')
         return callback
@@ -121,6 +123,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         self._register_callback(callback, 'message_preprocessor')
         return callback
@@ -140,6 +143,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         self._register_callback(callback, 'result_postprocessor')
         return callback
@@ -167,6 +171,7 @@ class Application:
             Unhandled exceptions resulting from processing a message
             while the consumer is still active will stop cause the
             application to shut down gracefully.
+
         """
         if self.consumer is None:
             raise TypeError("The Application's consumer cannot be None.")
@@ -272,6 +277,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         self._register_callback(callback, 'startup')
         return callback
@@ -290,6 +296,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         self._register_callback(callback, 'teardown')
         return callback
@@ -324,6 +331,7 @@ class Application:
 
         Returns:
             The return value of the final callback.
+
         """
         for callback in callbacks:
             value = yield from callback(self, value)
@@ -452,6 +460,7 @@ class Application:
 
         Raises:
             TypeError: If the callback isn't a coroutine.
+
         """
         if not asyncio.iscoroutinefunction(callback):
             raise TypeError('The callback must be a coroutine.')
@@ -482,6 +491,7 @@ def _new_event_loop():
 
     Returns:
         asyncio.AbstractEventLoopPolicy: The new event loop.
+
     """
     try:
         import uvloop

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -265,6 +265,7 @@ def _import_application(application_path):
     Returns:
         Tuple[str, henson.base.Application]: A two-tuple containing the
             import path and the imported application.
+
     """
     # Add the present working directory to the import path so that
     # services can be found without installing them to site-packages

--- a/henson/contrib/retry/__init__.py
+++ b/henson/contrib/retry/__init__.py
@@ -26,6 +26,7 @@ def _calculate_delay(delay, backoff, number_of_retries):
 
     Returns:
         numbers.Number: The amount of time to wait.
+
     """
     backoff_factor = backoff ** number_of_retries
     return delay * backoff_factor
@@ -43,6 +44,7 @@ def _exceeded_threshold(number_of_retries, maximum_retries):
     Returns:
         bool: True if the maximum number of retry attempts have already
             been made.
+
     """
     if maximum_retries is None:
         # Retry forever.
@@ -60,6 +62,7 @@ def _exceeded_timeout(start_time, duration):
 
     Returns:
         bool: True if the timeout has passed.
+
     """
     if duration is None:
         # Retry forever.
@@ -85,6 +88,7 @@ def _retry(app, message, exc):
 
     Raises:
         Abort: If the message is scheduled to be retried.
+
     """
     if not isinstance(exc, app.settings['RETRY_EXCEPTIONS']):
         # If the exception raised isn't retryable, return control so the
@@ -135,6 +139,7 @@ def _retry_info(message):
 
     Returns:
         dict: The retry attempt information.
+
     """
     info = message.get('_retry', {})
     info.setdefault('count', 0)
@@ -171,6 +176,7 @@ class Retry(Extension):
         Raises:
             TypeError: If the callback isn't a coroutine.
             ValueError: If the delay or backoff is negative.
+
         """
         super().init_app(app)
 

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,10 @@ envlist = docs,pep8,py34,py35,py36
 [testenv]
 deps =
     coverage
-    pytest
+    pytest<3.3
     pytest-asyncio<0.4.0
     pytest-capturelog
+    sphinx==1.7.0
     sphinxcontrib-autoprogram
 commands =
     python -m coverage run -m pytest --strict {posargs: tests}


### PR DESCRIPTION
- fix `PEP 257` errors
- pin `sphinx` to `1.7.0`, since versions higher than that introduce a change that is not available in all versions of Python 3.5.
- use earlier version of `pytest`, as newer ones seem to conflict with `pytest-capturelog`