### PR TITLE
Install sphinx<1.7.1 For Anyone Using Sphinx Extra

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -36,6 +36,7 @@ setup(
     ],
     extras_require={
         'sphinx': [
+            'sphinx<1.7.1',
             'sphinxcontrib-autoprogram>=0.1.3',
         ],
     },


### PR DESCRIPTION
This comes from Issue https://github.com/iheartradio/Henson/issues/150.

We need to install `sphinx<1.7.1` for anyone installing `Henson[sphinx]` so that docs can successfully build on versions of Python older than 3.5.2.