### PR TITLE
Use 'level' Getter That All Loggers Can Use

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -205,7 +205,9 @@ class Application:
             # log level was set to something lower than DEBUG, don't
             # change it.
             loop.set_debug(True)
-            self.logger.setLevel(min(self.logger.level, logging.DEBUG))
+            self.logger.setLevel(
+                min(self.logger.getEffectiveLevel(), logging.DEBUG)
+            )
 
         self.logger.debug('application.started')
 


### PR DESCRIPTION
Switch to the method, `getEffectiveLevel()`, which is supported by default logging as well as [Henson-Logging](https://github.com/iheartradio/Henson-Logging/blob/master/henson_logging/__init__.py#L100).