### PR TITLE
log messages for exceptions

### DIFF
--- a/henson/base.py
+++ b/henson/base.py
@@ -401,7 +401,8 @@ class Application:
             except Abort as e:
                 yield from self._abort(e)
             except Exception as e:
-                self.logger.error('message.failed', exc_info=sys.exc_info())
+                self.logger.error('message.failed', exc_info=sys.exc_info(),
+                                  message=original_message)
 
                 for callback in self._callbacks['error']:
                     # Any callback can prevent execution of further

--- a/henson/base.py
+++ b/henson/base.py
@@ -402,7 +402,7 @@ class Application:
                 yield from self._abort(e)
             except Exception as e:
                 self.logger.error('message.failed', exc_info=sys.exc_info(),
-                                  message=original_message)
+                                  extra={"original_message": original_message})
 
                 for callback in self._callbacks['error']:
                     # Any callback can prevent execution of further


### PR DESCRIPTION
Log original_message to exceptions. It's not currently possible to correlate message failures to top level Henson exceptions. 