### PR TITLE
Add support for Python 3.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,17 @@ language: python
 
 matrix:
   include:
-    - python: 3.4
-      env: TOX_ENV=py34
     - python: 3.5
       env: TOX_ENV=py35
     - python: 3.6
       env: TOX_ENV=py36
-    - python: 3.6
+    - python: 3.7
       env: TOX_ENV=docs
-    - python: 3.6
+    - python: 3.7
       env: TOX_ENV=pep8
+    - python: 3.7
+      dist: bionic
+      env: TOX_ENV=py37
 
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/henson/base.py
+++ b/henson/base.py
@@ -185,7 +185,7 @@ class Application:
 
         # Start the application.
         tasks = [
-            asyncio.async(callback(self), loop=loop) for callback in
+            asyncio.ensure_future(callback(self), loop=loop) for callback in
             self._callbacks['startup']
         ]
         future = asyncio.gather(*tasks, loop=loop)
@@ -224,7 +224,10 @@ class Application:
         # running it should be restarted and wait until the future is
         # done.
         tasks = [
-            asyncio.async(self._process(consumer, queue, loop), loop=loop)
+            asyncio.ensure_future(
+                self._process(consumer, queue, loop),
+                loop=loop
+            )
             for _ in range(num_workers)
         ]
         future = asyncio.gather(*tasks, loop=loop)
@@ -254,8 +257,9 @@ class Application:
 
             # Teardown
             tasks = [
-                asyncio.async(callback(self), loop=loop) for callback in
-                self._callbacks['teardown']
+                asyncio.ensure_future(callback(self), loop=loop)
+                for callback
+                in self._callbacks['teardown']
             ]
             future = asyncio.gather(*tasks, loop=loop)
             loop.run_until_complete(future)
@@ -477,7 +481,7 @@ class Application:
     def _teardown(self, future, loop):
         """Tear down the application."""
         tasks = [
-            asyncio.async(callback(self), loop=loop) for callback in
+            asyncio.ensure_future(callback(self), loop=loop) for callback in
             self._callbacks['teardown']]
         future = asyncio.gather(*tasks, loop=loop)
         loop.run_until_complete(future)

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -30,7 +30,7 @@ class Extension:
             self.init_app(app)
 
     @property
-    def DEFAULT_SETTINGS(self):  # NOQA
+    def DEFAULT_SETTINGS(self):  # NOQA: D401,N802
         """A ``dict`` of default settings for the extension.
 
         When a setting is not specified by the application instance and
@@ -41,7 +41,7 @@ class Extension:
         return {}
 
     @property
-    def REQUIRED_SETTINGS(self):  # NOQA
+    def REQUIRED_SETTINGS(self):  # NOQA: D401,N802
         """An ``iterable`` of required settings for the extension.
 
         When an extension has required settings that do not have default

--- a/setup.py
+++ b/setup.py
@@ -58,9 +58,9 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.4',
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tests/test_application.py
+++ b/tests/test_application.py
@@ -42,7 +42,7 @@ def test_consume(event_loop, test_consumer):
 
     app = Application('testing', consumer=test_consumer)
 
-    asyncio.async(app._consume(queue))
+    asyncio.ensure_future(app._consume(queue), loop=event_loop)
 
     event_loop.stop()  # Run the event loop once.
     event_loop.run_forever()

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -286,7 +286,7 @@ def test_run_forever(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that run_forever is called on the imported app."""
     cli.run('good_import:app', **cli_kwargs)
     out, _ = capsys.readouterr()
-    assert 'Running <Application: testing> forever' in caplog.text()
+    assert 'Running <Application: testing> forever' in caplog.text
     assert 'Run, Forrest, run!' in out
 
 
@@ -294,5 +294,5 @@ def test_run_with_reloader(good_mock_service, cli_kwargs, caplog, capsys):
     """Test that an app is run with the reloader."""
     cli.run('good_import:app', reloader=True, **cli_kwargs)
     out, _ = capsys.readouterr()
-    assert 'Running <Application: testing> with reloader' in caplog.text()
+    assert 'Running <Application: testing> with reloader' in caplog.text
     assert 'Run, Forrest, run!' in out

--- a/tox.ini
+++ b/tox.ini
@@ -1,11 +1,11 @@
 [tox]
-envlist = docs,pep8,py34,py35,py36
+envlist = docs,pep8,py35,py36,py37
 
 [testenv]
 deps =
     coverage
-    pytest<3.3
-    pytest-asyncio<0.4.0
+    pytest
+    pytest-asyncio
     pytest-capturelog
     sphinx==1.7.0
     sphinxcontrib-autoprogram
@@ -14,16 +14,18 @@ commands =
     python -m coverage report -m --include="henson/*"
 
 [testenv:docs]
-basepython = python3.6
+basepython = python3.7
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.6
+basepython = python3.7
 deps =
+    flake8<3.6.0
     flake8-docstrings
     pep8-naming
+    pydocstyle<3.0
 commands =
     flake8 henson


### PR DESCRIPTION
This PR adds supports for Python 3.7. It also updates the Python version for the `docs` and `pep8` tox environments.