### PR TITLE
Update To Python 3.8 and 3.9, drop support for everything below

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,17 +2,15 @@ language: python
 
 matrix:
   include:
-    - python: 3.5
-      env: TOX_ENV=py35
-    - python: 3.6
-      env: TOX_ENV=py36
-    - python: 3.7
+    - python: 3.8
+      env: TOX_ENV=py38
+    - python: 3.9
       env: TOX_ENV=docs
-    - python: 3.7
+    - python: 3.9
       env: TOX_ENV=pep8
-    - python: 3.7
+    - python: 3.9
       dist: bionic
-      env: TOX_ENV=py37
+      env: TOX_ENV=py39
 
 install: pip install tox
 script: tox -e $TOX_ENV

--- a/henson/cli.py
+++ b/henson/cli.py
@@ -5,7 +5,8 @@ from collections import Counter
 from copy import deepcopy
 from contextlib import suppress
 from functools import wraps
-from importlib import find_loader, import_module
+from importlib import import_module
+from importlib.util import find_spec
 import inspect
 import logging
 import os
@@ -279,7 +280,7 @@ def _import_application(application_path):
     # Then, try to find an import loader for the import_path
     # NOTE: this is to handle the case where a module is found but not
     # importable because of dependency import errors (Python 3 only)
-    if not find_loader(import_path):
+    if not find_spec(import_path):
         raise CommandError(
             'Unable to find an import loader for {}.'.format(import_path),
         )

--- a/henson/contrib/retry/__init__.py
+++ b/henson/contrib/retry/__init__.py
@@ -72,8 +72,7 @@ def _exceeded_timeout(start_time, duration):
     return start_time + (duration * 1000) <= int(time.time())
 
 
-@asyncio.coroutine
-def _retry(app, message, exc):
+async def _retry(app, message, exc):
     """Retry the message.
 
     An exception that is included as a retryable type will result in the
@@ -119,12 +118,12 @@ def _retry(app, message, exc):
             backoff=app.settings['RETRY_BACKOFF'],
             number_of_retries=retry_info['count'],
         )
-        yield from asyncio.sleep(retry_info['delay'])
+        await asyncio.sleep(retry_info['delay'])
 
     # Update the retry information and retry the message.
     retry_info['count'] += 1
     message['_retry'] = retry_info
-    yield from app.settings['RETRY_CALLBACK'](app, message)
+    await app.settings['RETRY_CALLBACK'](app, message)
 
     # If the exception was retryable, none of the other callbacks should
     # execute.

--- a/henson/extensions.py
+++ b/henson/extensions.py
@@ -30,18 +30,18 @@ class Extension:
             self.init_app(app)
 
     @property
-    def DEFAULT_SETTINGS(self):  # NOQA: D401,N802
+    def DEFAULT_SETTINGS(self):  # NOQA: N802
         """A ``dict`` of default settings for the extension.
 
         When a setting is not specified by the application instance and
         has a default specified, the default value will be used.
         Extensions should define this where appropriate. Defaults to
         ``{}``.
-        """
+        """  # NOQA: D401
         return {}
 
     @property
-    def REQUIRED_SETTINGS(self):  # NOQA: D401,N802
+    def REQUIRED_SETTINGS(self):  # NOQA: N802
         """An ``iterable`` of required settings for the extension.
 
         When an extension has required settings that do not have default
@@ -49,7 +49,7 @@ class Extension:
         initialization, an exception will be raised if a value is not
         set for each key specified in this list. Extensions should
         define this where appropriate. Defaults to ``()``.
-        """
+        """  # NOQA: D401
         return ()
 
     def init_app(self, app):

--- a/setup.py
+++ b/setup.py
@@ -20,7 +20,7 @@ def read(filename):
 
 setup(
     name='Henson',
-    version='2.1.0',
+    version='2.2.0',
     author='Aditya Ghosh, Leonard Bedner, Zack Morris, and others',
     author_email='henson@iheart.com',
     url='https://henson.readthedocs.io',
@@ -58,9 +58,8 @@ setup(
         'Natural Language :: English',
         'Operating System :: POSIX',
         'Programming Language :: Python',
-        'Programming Language :: Python :: 3.5',
-        'Programming Language :: Python :: 3.6',
-        'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
+        'Programming Language :: Python :: 3.9',
         'Programming Language :: Python :: 3 :: Only',
         'Topic :: Software Development :: Libraries :: Application Frameworks',
     ]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -29,8 +29,7 @@ class MockApplication(Application):
 class MockConsumer:
     """A stub consumer that can be used for testing."""
 
-    @asyncio.coroutine
-    def read(self):
+    async def read(self):
         """Return an item."""
         return 1
 
@@ -40,8 +39,7 @@ class MockAbortingConsumer:
 
     _run = False
 
-    @asyncio.coroutine
-    def read(self):
+    async def read(self):
         """Return an item."""
         if self._run:
             raise Abort('testing', {})
@@ -61,8 +59,7 @@ def cancelled_future(event_loop):
 @pytest.fixture
 def coroutine():
     """Return a coroutine function."""
-    @asyncio.coroutine
-    def _inner(*args, **kwargs):
+    async def _inner(*args, **kwargs):
         pass
     return _inner
 

--- a/tests/test_exceptions.py
+++ b/tests/test_exceptions.py
@@ -18,8 +18,7 @@ def test_abort_preprocessor(event_loop, cancelled_future, queue):
 
     queue.put_nowait({'a': 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         nonlocal callback_called
         callback_called = True
         return message
@@ -27,22 +26,19 @@ def test_abort_preprocessor(event_loop, cancelled_future, queue):
     app = Application('testing', callback=callback)
 
     @app.message_preprocessor
-    @asyncio.coroutine
-    def preprocess1(app, message):
+    async def preprocess1(app, message):
         nonlocal preprocess1_called
         preprocess1_called = True
         raise exceptions.Abort('testing', message)
 
     @app.message_preprocessor
-    @asyncio.coroutine
-    def preprocess2(app, message):
+    async def preprocess2(app, message):
         nonlocal preprocess2_called
         preprocess2_called = True
         return message
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess(app, result):
+    async def postprocess(app, result):
         nonlocal postprocess_called
         postprocess_called = True
         return result
@@ -66,8 +62,7 @@ def test_abort_callback(event_loop, cancelled_future, queue):
 
     queue.put_nowait({'a': 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         nonlocal callback_called
         callback_called = True
         raise exceptions.Abort('testing', message)
@@ -75,8 +70,7 @@ def test_abort_callback(event_loop, cancelled_future, queue):
     app = Application('testing', callback=callback)
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess(app, result):
+    async def postprocess(app, result):
         nonlocal postprocess_called
         postprocess_called = True
         return result
@@ -99,8 +93,7 @@ def test_abort_error(event_loop, cancelled_future, queue):
 
     queue.put_nowait({'a': 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         nonlocal callback_called
         callback_called = True
         raise TypeError('testing')
@@ -108,15 +101,13 @@ def test_abort_error(event_loop, cancelled_future, queue):
     app = Application('testing', callback=callback)
 
     @app.error
-    @asyncio.coroutine
-    def error1(app, message, exc):
+    async def error1(app, message, exc):
         nonlocal error1_called
         error1_called = True
         raise exceptions.Abort('testing', message)
 
     @app.error
-    @asyncio.coroutine
-    def error2(app, message, exc):
+    async def error2(app, message, exc):
         nonlocal error2_called
         error2_called = True
 
@@ -138,15 +129,13 @@ def test_abort_postprocess(event_loop, cancelled_future, queue):
 
     queue.put_nowait({'a': 1})
 
-    @asyncio.coroutine
-    def callback(app, message):
+    async def callback(app, message):
         return [True, False]
 
     app = Application('testing', callback=callback)
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess1(app, result):
+    async def postprocess1(app, result):
         nonlocal postprocess1_called_count
         postprocess1_called_count += 1
         if result:
@@ -154,8 +143,7 @@ def test_abort_postprocess(event_loop, cancelled_future, queue):
         return result
 
     @app.result_postprocessor
-    @asyncio.coroutine
-    def postprocess2(app, result):
+    async def postprocess2(app, result):
         nonlocal postprocess2_called_count
         postprocess2_called_count += 1
         return result

--- a/tox.ini
+++ b/tox.ini
@@ -1,31 +1,28 @@
 [tox]
-envlist = docs,pep8,py35,py36,py37
+envlist = docs,pep8,py38,py39
 
 [testenv]
 deps =
     coverage
     pytest
     pytest-asyncio
-    pytest-capturelog
     sphinx==1.7.0
     sphinxcontrib-autoprogram
 commands =
-    python -m coverage run -m pytest --strict {posargs: tests}
+    python -m coverage run -m pytest --strict-markers {posargs: tests}
     python -m coverage report -m --include="henson/*"
 
 [testenv:docs]
-basepython = python3.7
+basepython = python3.9
 deps = -rdocs-requirements.txt
 commands =
     sphinx-build -W -b html -d {envtmpdir}/doctrees docs docs/_build/html
     doc8 --allow-long-titles README.rst docs/ --ignore-path docs/_build/
 
 [testenv:pep8]
-basepython = python3.7
+basepython = python3.9
 deps =
-    flake8<3.6.0
     flake8-docstrings
     pep8-naming
-    pydocstyle<3.0
 commands =
-    flake8 henson
+    flake8 --ignore F722 henson


### PR DESCRIPTION
- remove support for Python <= 3.7
- add support for Python >= 3.8
- stopped using `@asyncio.coroutine`, added `async` to all appropriate methods, since the former is deprecated
- replaced `yield from` -> `await` where applicable, since the former is deprecated
- ignore `pep8` `F722` since `flake8` cannot distinguish between type annotations and argument comments at the moment
- no reason to specify `loop=loop` to get the event loop, as [discussed here](https://stackoverflow.com/questions/60312374/what-are-all-these-deprecated-loop-parameters-in-asyncio?answertab=votes#tab-top)
- moved `pep8` `D401` so it properly checks the property doc strings