### PR TITLE
Added Override Settings To Retry contrib Package

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -1,3 +1,10 @@
+Version 2.3.0
+-------------
+
+Released TBD
+
+- add support for settings overrides in the ``contrib`` package, ``retry``.
+
 Version 2.2.0
 -------------
 

--- a/docs/contrib/retry.rst
+++ b/docs/contrib/retry.rst
@@ -20,9 +20,9 @@ Configuration
 =============
 
 Retry provides a couple of settings to control how many times a message will be
-retried. ``RETRY_THESHOLD`` and ``RETRY_TIMEOUT`` work in tandem. If values are
-specified for both, whichever limit is reached first will cause Henson to stop
-retrying the message. By default, Henson will try forever (yes, this is
+retried. ``RETRY_THRESHOLD`` and ``RETRY_TIMEOUT`` work in tandem. If values
+are specified for both, whichever limit is reached first will cause Henson to
+stop retrying the message. By default, Henson will try forever (yes, this is
 literally insane).
 
 +----------------------+------------------------------------------------------+
@@ -56,6 +56,39 @@ literally insane).
 |                      | can be retried. If set to None, the limit will be    |
 |                      | controlled by ``RETRY_THRESHOLD``. Defaults to None. |
 +----------------------+------------------------------------------------------+
+
+Retry Overrides
+---------------
+
+This is a setting you can make use of to override the global setings for all
+retried exceptions, and tailor settings specific to a particular excpetion
+you're retrying.
+
+For instance, you may want to retry an ``IOError`` exception forever (keeping
+with the insanity theme), however, with ``FileNotFoundError`` exceptions, you
+may only want to retry it twice using {``'RETRY_THRESHOLD': 2``}).
+
++----------------------+------------------------------------------------------+
+| ``RETRY_OVERRIDES``  | Dictionary of settings, with the key being a specific|
+|                      | exception, and the value being settings to override. |
+|                      | Exceptions not within the base ``RETRY_EXCEPTIONS``  |
+|                      | will be ignored.                                     |
++----------------------+------------------------------------------------------+
+
+An example::
+
+    {
+        'RETRY_BACKOFF': 1,
+        'RETRY_DELAY': 0,
+        'RETRY_EXCEPTIONS': (IOError, FileNotFoundError),
+        'RETRY_THRESHOLD': None,
+        'RETRY_TIMEOUT': None,
+        'RETRY_OVERRIDES': {
+            FileNotFoundError: {
+                'RETRY_THESHOLD': 2,
+            }
+        },
+    }
 
 Usage
 =====

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ deps =
     sphinx==1.7.0
     sphinxcontrib-autoprogram
 commands =
-    python -m coverage run -m pytest --strict-markers {posargs: tests}
+    python -m coverage run -m pytest -vv --strict-markers {posargs: tests}
     python -m coverage report -m --include="henson/*"
 
 [testenv:docs]
@@ -25,4 +25,4 @@ deps =
     flake8-docstrings
     pep8-naming
 commands =
-    flake8 --ignore F722 henson
+    flake8 --ignore F722,N818 henson


### PR DESCRIPTION
Retry Overrides
---------------

This is a setting you can make use of to override the global settings for all retried exceptions, and tailor settings specific to a particular exception you're retrying.

For instance, you may want to retry an ``IOError`` exception forever (keeping with the insanity theme), however, with ``FileNotFoundError`` exceptions, you may only want to retry it twice using ``'RETRY_THRESHOLD': 2``.

| ``RETRY_OVERRIDES``| Dictionary of settings, with the key being a specific exception, and the value being settings to override. Exceptions not within the base ``RETRY_EXCEPTIONS`` will be ignored. |
|-----------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------|


An example:

    {
        'RETRY_BACKOFF': 1,
        'RETRY_DELAY': 0,
        'RETRY_EXCEPTIONS': (IOError, FileNotFoundError),
        'RETRY_THRESHOLD': None,
        'RETRY_TIMEOUT': None,
        'RETRY_OVERRIDES': {
            FileNotFoundError: {
                'RETRY_THESHOLD': 2,
            }
        },
    }